### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ Good starting points in the bundle:
 
 ## dStruct (this repo)
 
-**Precedence:** The section above is the source of truth for **Next.js** (framework APIs, App Router, `next.config`, version-specific behavior). **`.cursor/rules/`** is the source of truth for **this repo’s code style and patterns**. If bundled Next.js docs or generic examples disagree with a Cursor rule—hook imports, type imports, comment conventions—**follow the Cursor rule** for code in this repository.
+**Precedence:** The section above is the source of truth for **Next.js** (framework APIs, App Router, `next.config`, version-specific behavior). **`.cursor/rules/`** is the source of truth for **this repo's code style and patterns**. If bundled Next.js docs or generic examples disagree with a Cursor rule—hook imports, type imports, comment conventions—**follow the Cursor rule** for code in this repository.
 
 Cursor rules to apply (see each file for full wording):
 
@@ -23,3 +23,47 @@ Cursor rules to apply (see each file for full wording):
 - `useeffect-business-logic-comments.mdc` — short comments above non-trivial `useEffect` hooks that encode business logic
 
 **Tooling:** Use **pnpm** for installs and scripts (`pnpm install`, `pnpm dev`, `pnpm lint`, `pnpm test`). Local dev: `pnpm dev`. Prefer iterating with the dev server rather than repeated full production builds during exploration.
+
+## Cursor Cloud specific instructions
+
+### Services overview
+
+| Service | Command | Notes |
+|---|---|---|
+| Next.js dev server | `pnpm dev` | Runs on `http://localhost:3000`. Core app (frontend + tRPC API). |
+| PostgreSQL | `sudo service postgresql start` | Must be running before dev server or any DB commands. |
+| Python runner (optional) | `pnpm runners:dev` | Only needed for server-side Python code execution. |
+
+### Node.js version
+
+The project requires **Node.js 24** (`engines.node: "^v24.11.1"` in `package.json`). Use `nvm use 24` before running any commands. The `.nvmrc` file is set to `24`.
+
+### Database
+
+- PostgreSQL with user `dstruct`, password `dstruct`, database `dstruct` on `localhost:5432`.
+- After starting PostgreSQL, push the schema with `pnpm prisma:push`.
+- To seed with sample data: `SKIP_ENV_VALIDATION=true PRISMA_FIELD_ENCRYPTION_KEY=dev-local-encryption-key-for-testing-only DATABASE_URL=postgresql://dstruct:dstruct@localhost:5432/dstruct pnpm loadMainDump`.
+
+### Environment variables
+
+- A `.env` file must exist at the repo root. See `.env.example` for the template.
+- Many env vars (OAuth, AWS) are validated at startup but can use placeholder values for local dev since those features won't be exercised.
+- Set `SKIP_ENV_VALIDATION=true` to bypass env validation for scripts and tests.
+- The `PRISMA_FIELD_ENCRYPTION_KEY` value is a passphrase (not the old `k1.aesgcm256.*` format); any non-empty string works for local dev.
+
+### Key development commands
+
+Refer to `package.json` scripts. Summary of most-used:
+
+- **Dev server**: `pnpm dev`
+- **Lint**: `pnpm lint` (runs ESLint + TypeScript `--noEmit`)
+- **Tests**: `pnpm test:ci` (single run) or `pnpm test` (watch mode)
+- **Prisma generate**: `pnpm prisma:generate` (auto-run by `postinstall`)
+- **GraphQL codegen**: `pnpm generate-graphql` (auto-run by `postinstall`)
+
+### Gotchas
+
+- The `/api/config` endpoint uses `@vercel/edge-config` which requires Vercel's `EDGE_CONFIG` env var. It returns 404 locally but the app handles this gracefully — the playground still works fully.
+- The `postinstall` script runs `prisma:generate`, `generate-graphql`, creates a Python venv, and installs `black`. Ensure `python3-venv` is installed on the system.
+- `pnpm typesafe-i18n` is a **file watcher** that never exits. Do not run it in a blocking terminal session; run in background or skip.
+- Pre-commit hook runs `prettier --write` via `lint-staged`. Pre-push hook runs `pnpm lint`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud-specific development environment instructions, covering:

- Services overview (Next.js, PostgreSQL, Python runner)
- Node.js 24 version requirement
- Database setup (PostgreSQL credentials, schema push, data seeding)
- Environment variables and `.env` configuration
- Key development commands (dev, lint, test, prisma, graphql)
- Known gotchas (Edge Config 404 locally, postinstall venv, typesafe-i18n watcher, git hooks)

## Walkthrough

[dstruct_playground_code_execution_demo.mp4](https://cursor.com/agents/bc-6c653571-bdf8-499f-9f7c-33e3b75d895d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdstruct_playground_code_execution_demo.mp4)
Full playground demo: loading a project, running code, visualizing binary tree traversal with time-travel debugging.

[Playground loaded with problem](https://cursor.com/agents/bc-6c653571-bdf8-499f-9f7c-33e3b75d895d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fplayground_loaded.webp)
[Code execution with colored tree visualization](https://cursor.com/agents/bc-6c653571-bdf8-499f-9f7c-33e3b75d895d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fcode_execution_visualization.webp)
[Execution success with output](https://cursor.com/agents/bc-6c653571-bdf8-499f-9f7c-33e3b75d895d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fexecution_success_output.webp)

## Testing

- ✅ `pnpm lint` — 0 errors (80 warnings, all pre-existing `@typescript-eslint/no-explicit-any`)
- ✅ `pnpm test:ci` — 29 test files, 230 tests passed
- ✅ `pnpm dev` — Next.js dev server starts on port 3000
- ✅ Playground loads, code executes, tree visualization works end-to-end

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6c653571-bdf8-499f-9f7c-33e3b75d895d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6c653571-bdf8-499f-9f7c-33e3b75d895d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

