### PR TITLE
Add Dark Reader lock meta for always-dark UI

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -20,6 +20,7 @@ function Document({ emotionStyleTags }: MyDocumentProps) {
           name="viewport"
           content="width=device-width, initial-scale=1, viewport-fit=cover"
         />
+        <meta name="darkreader-lock" />
         <meta
           name="description"
           content="dStruct is a web app that helps you understand LeetCode problems. It allows you to visualize your solutions that you write in a built-in code editor."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `<meta name="darkreader-lock" />` to the document head so the [Dark Reader](https://github.com/darkreader/darkreader) browser extension does not apply its own darkening on dStruct. The app is already dark-themed, so double-filtering was unnecessary and could harm contrast and branding.

## Change

- `src/pages/_document.tsx`: insert `darkreader-lock` meta next to other global head tags (after viewport).

## Merge with `main`

Merged latest `main`; `_document` conflict was resolved by keeping `main`'s `htmlLang` / SEO refactor (meta tags moved to `SiteSeoHead`) and retaining `darkreader-lock` only in `_document`.

## Notes

- This is recognized by Dark Reader (Chrome/Firefox); other extensions may not honor it.
- If the product later adds a real light theme, this meta should be removed or injected only when the active theme is dark.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-41cfbd2d-ced9-4200-bf05-4c21bf438294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-41cfbd2d-ced9-4200-bf05-4c21bf438294"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

