### PR TITLE
Enforce Prettier formatting via ESLint (prettier/prettier)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,5 @@
 import nextPlugin from "@next/eslint-plugin-next";
+import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
 import reactHooksPlugin from "eslint-plugin-react-hooks";
 import testingLibrary from "eslint-plugin-testing-library";
 import tseslint from "typescript-eslint";
@@ -14,6 +15,7 @@ const eslintConfig = [
       "**/dist/**",
       "**/coverage/**",
       "src/graphql/generated/**",
+      "src/server/db/generated/**",
       ".next/**",
       "node_modules/**",
     ],
@@ -95,6 +97,8 @@ const eslintConfig = [
       ...testingLibrary.configs.react.rules,
     },
   },
+  // Last: Prettier as ESLint rule + disable conflicting formatting rules
+  eslintPluginPrettierRecommended,
 ];
 
 export default eslintConfig;

--- a/package.json
+++ b/package.json
@@ -142,6 +142,8 @@
     "es-guard": "^1.20.0",
     "esbuild": "^0.27.7",
     "eslint": "^9.39.4",
+    "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-testing-library": "^7.16.2",
     "gltfjsx": "^6.5.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -300,6 +300,12 @@ importers:
       eslint:
         specifier: ^9.39.4
         version: 9.39.4(jiti@2.6.1)
+      eslint-config-prettier:
+        specifier: ^10.1.8
+        version: 10.1.8(eslint@9.39.4(jiti@2.6.1))
+      eslint-plugin-prettier:
+        specifier: ^5.5.5
+        version: 5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.1)
       eslint-plugin-react-hooks:
         specifier: ^7.0.1
         version: 7.0.1(eslint@9.39.4(jiti@2.6.1))
@@ -1932,6 +1938,10 @@ packages:
   '@parcel/watcher@2.5.6':
     resolution: {integrity: sha512-tmmZ3lQxAe/k/+rNnXQRawJ4NjxO2hqiOLTHvWchtGZULp4RyFeh6aU4XdOYBFe2KE1oShQTv4AblOs2iOrNnQ==}
     engines: {node: '>= 10.0.0'}
+
+  '@pkgr/core@0.2.9':
+    resolution: {integrity: sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==}
+    engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
   '@pnpm/config.env-replace@1.1.0':
     resolution: {integrity: sha512-htyl8TWnKL7K/ESFa1oW2UB5lVDxuF5DpM7tBi6Hu2LNL3mWkIzNLG6N4zoCUP1lCKNxWy/3iu8mS8MvToGd6w==}
@@ -3725,11 +3735,31 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
+  eslint-config-prettier@10.1.8:
+    resolution: {integrity: sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==}
+    hasBin: true
+    peerDependencies:
+      eslint: '>=7.0.0'
+
   eslint-plugin-compat@7.0.1:
     resolution: {integrity: sha512-wDID2fVIAfxV9R1uSkCn5HscnNu8yMxDF1IaQGyD1C6XuWwJbuaDgMOSkVgOom0LzY8z0fXXXCy7AQQTERQUvQ==}
     engines: {node: '>=18.x'}
     peerDependencies:
       eslint: ^9.0.0 || ^10.0.0
+
+  eslint-plugin-prettier@5.5.5:
+    resolution: {integrity: sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==}
+    engines: {node: ^14.18.0 || >=16.0.0}
+    peerDependencies:
+      '@types/eslint': '>=8.0.0'
+      eslint: '>=8.0.0'
+      eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
+      prettier: '>=3.0.0'
+    peerDependenciesMeta:
+      '@types/eslint':
+        optional: true
+      eslint-config-prettier:
+        optional: true
 
   eslint-plugin-react-hooks@7.0.1:
     resolution: {integrity: sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==}
@@ -3865,6 +3895,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-diff@1.3.0:
+    resolution: {integrity: sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==}
 
   fast-glob@3.3.1:
     resolution: {integrity: sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==}
@@ -5636,6 +5669,10 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  prettier-linter-helpers@1.0.1:
+    resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
+    engines: {node: '>=6.0.0'}
+
   prettier@3.1.1:
     resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==}
     engines: {node: '>=14'}
@@ -6364,6 +6401,10 @@ packages:
   sync-fetch@0.6.0-2:
     resolution: {integrity: sha512-c7AfkZ9udatCuAy9RSfiGPpeOKKUAUK5e1cXadLOGUjasdxqYqAK0jTNkM/FSEyJ3a5Ra27j/tw/PS0qLmaF/A==}
     engines: {node: '>=18'}
+
+  synckit@0.11.12:
+    resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
+    engines: {node: ^14.18.0 || >=16.0.0}
 
   tagged-tag@1.0.0:
     resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
@@ -8782,6 +8823,8 @@ snapshots:
       '@parcel/watcher-win32-x64': 2.5.6
     optional: true
 
+  '@pkgr/core@0.2.9': {}
+
   '@pnpm/config.env-replace@1.1.0': {}
 
   '@pnpm/network.ca-file@1.0.2':
@@ -10670,6 +10713,10 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
+  eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)):
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+
   eslint-plugin-compat@7.0.1(eslint@10.2.0(jiti@2.6.1)):
     dependencies:
       '@mdn/browser-compat-data': 6.1.5
@@ -10680,6 +10727,16 @@ snapshots:
       globals: 15.15.0
       lodash.memoize: 4.1.2
       semver: 7.7.4
+
+  eslint-plugin-prettier@5.5.5(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))(prettier@3.8.1):
+    dependencies:
+      eslint: 9.39.4(jiti@2.6.1)
+      prettier: 3.8.1
+      prettier-linter-helpers: 1.0.1
+      synckit: 0.11.12
+    optionalDependencies:
+      '@types/eslint': 9.6.1
+      eslint-config-prettier: 10.1.8(eslint@9.39.4(jiti@2.6.1))
 
   eslint-plugin-react-hooks@7.0.1(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
@@ -10923,6 +10980,8 @@ snapshots:
   fast-content-type-parse@3.0.0: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-diff@1.3.0: {}
 
   fast-glob@3.3.1:
     dependencies:
@@ -12605,6 +12664,10 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  prettier-linter-helpers@1.0.1:
+    dependencies:
+      fast-diff: 1.3.0
+
   prettier@3.1.1: {}
 
   prettier@3.8.1: {}
@@ -13444,6 +13507,10 @@ snapshots:
       node-fetch: 3.3.2
       timeout-signal: 2.0.0
       whatwg-mimetype: 4.0.0
+
+  synckit@0.11.12:
+    dependencies:
+      '@pkgr/core': 0.2.9
 
   tagged-tag@1.0.0: {}
 

--- a/src/features/homePage/ui/QuestionSummary.tsx
+++ b/src/features/homePage/ui/QuestionSummary.tsx
@@ -71,8 +71,10 @@ const DifficultyIconMap: Record<keyof typeof Difficulty, typeof SvgIcon> = {
   Hard: SignalCellular4Bar,
 };
 
-interface QuestionSummaryProps
-  extends Exclude<BoxProps, "position" | "zIndex"> {
+interface QuestionSummaryProps extends Exclude<
+  BoxProps,
+  "position" | "zIndex"
+> {
   questionDataQuery: QuestionDataQueryResult;
 }
 

--- a/src/features/profile/ui/UserSettings.tsx
+++ b/src/features/profile/ui/UserSettings.tsx
@@ -45,7 +45,7 @@ export const UserSettings: React.FC = () => {
 
   const loading = Boolean(
     userId &&
-      (gqlLoading || linkUser.isPending || unlinkUser.isPending || isLoading),
+    (gqlLoading || linkUser.isPending || unlinkUser.isPending || isLoading),
   );
 
   const handleLinkedUserReset = async () => {

--- a/src/pages/playground/[[...slug]].tsx
+++ b/src/pages/playground/[[...slug]].tsx
@@ -14,19 +14,19 @@ import { db } from "#/server/db/client";
 import { useAppConfig, useHasMounted } from "#/shared/hooks";
 import { useMobileLayout } from "#/shared/hooks/useMobileLayout";
 import {
-  resolveSsrDeviceType,
-  setDeviceHintResponseHeaders,
-} from "#/shared/lib/ssrDevice";
-import { PageScrollContainer } from "#/shared/ui/templates/PageScrollContainer";
-import type { SplitPanelsLayoutProps } from "#/shared/ui/templates/SplitPanelsLayout/SplitPanelsLayout";
-import { SplitPanelsLayout } from "#/shared/ui/templates/SplitPanelsLayout/SplitPanelsLayout";
-import { SplitPanelsLayoutSkeleton } from "#/shared/ui/templates/SplitPanelsLayout/SplitPanelsLayoutSkeleton";
-import {
   absoluteUrlFromPathname,
   DEFAULT_SITE_DESCRIPTION,
   pathnameFromResolvedUrl,
 } from "#/shared/lib/seo";
+import {
+  resolveSsrDeviceType,
+  setDeviceHintResponseHeaders,
+} from "#/shared/lib/ssrDevice";
 import { SiteSeoHead } from "#/shared/ui/seo/SiteSeoHead";
+import { PageScrollContainer } from "#/shared/ui/templates/PageScrollContainer";
+import type { SplitPanelsLayoutProps } from "#/shared/ui/templates/SplitPanelsLayout/SplitPanelsLayout";
+import { SplitPanelsLayout } from "#/shared/ui/templates/SplitPanelsLayout/SplitPanelsLayout";
+import { SplitPanelsLayoutSkeleton } from "#/shared/ui/templates/SplitPanelsLayout/SplitPanelsLayoutSkeleton";
 import type { SsrDeviceType } from "#/themes";
 
 type DesktopWrapperProps = SplitPanelsLayoutProps;

--- a/src/pages/profile/[userId].tsx
+++ b/src/pages/profile/[userId].tsx
@@ -171,8 +171,7 @@ export const getServerSideProps: GetServerSideProps<ProfilePageProps> = async (
     return { notFound: true };
   }
   const pathOnly =
-    pathnameFromResolvedUrl(ctx.resolvedUrl) ||
-    `/profile/${profileUserId}`;
+    pathnameFromResolvedUrl(ctx.resolvedUrl) || `/profile/${profileUserId}`;
   const canonicalUrl = absoluteUrlFromPathname(pathOnly);
   return { props: { canonicalUrl } };
 };

--- a/src/shared/lib/seo.ts
+++ b/src/shared/lib/seo.ts
@@ -41,7 +41,8 @@ export const DEFAULT_SITE_DESCRIPTION =
 const DEFAULT_OG_IMAGE_PATH = "/static/screen2.png";
 
 /** Default Open Graph / Twitter image URL for pages that do not set a custom preview image. */
-export const DEFAULT_OG_IMAGE_URL = `${SITE_ORIGIN}${DEFAULT_OG_IMAGE_PATH}` as const;
+export const DEFAULT_OG_IMAGE_URL =
+  `${SITE_ORIGIN}${DEFAULT_OG_IMAGE_PATH}` as const;
 
 /**
  * Escapes `& < > " '` so a string is safe inside XML text nodes (e.g. sitemap `<loc>`).
@@ -65,7 +66,10 @@ export const escapeXmlText = (unsafe: string): string =>
  * @param maxLength - Maximum characters before appending an ellipsis (default 155).
  * @returns Trimmed description, with `…` if truncated.
  */
-export const truncateMetaDescription = (text: string, maxLength = 155): string => {
+export const truncateMetaDescription = (
+  text: string,
+  maxLength = 155,
+): string => {
   const normalized = text.replace(/\s+/g, " ").trim();
   if (normalized.length <= maxLength) {
     return normalized;

--- a/src/shared/ui/seo/SiteSeoHead.tsx
+++ b/src/shared/ui/seo/SiteSeoHead.tsx
@@ -44,7 +44,9 @@ export const SiteSeoHead: React.FC<SiteSeoHeadProps> = ({
   noFollowWhenNoindex = false,
 }) => {
   const metaDescription = truncateMetaDescription(description);
-  const robotsWhenNoindex = noFollowWhenNoindex ? "noindex, nofollow" : "noindex, follow";
+  const robotsWhenNoindex = noFollowWhenNoindex
+    ? "noindex, nofollow"
+    : "noindex, follow";
 
   return (
     <Head>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **`eslint-plugin-prettier`** with the official **`eslint-plugin-prettier/recommended`** flat config so ESLint reports **`prettier/prettier`** as an **error** when source does not match Prettier output (using the repo `.prettierrc`, including `@trivago/prettier-plugin-sort-imports`).

Also applies **`eslint-config-prettier`** last to turn off ESLint rules that conflict with Prettier.

## Generated code

**`src/server/db/generated/**`** is added to ESLint ignores (same idea as `src/graphql/generated/**`) so Prisma client output is not blocked by formatting rules.

## Housekeeping

Ran Prettier on a few hand-written files that were already out of sync so `pnpm lint` stays green.

## Verification

- `pnpm lint` (ESLint + `tsc --noEmit`)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9c696104-e617-459e-8096-1b9a201af203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9c696104-e617-459e-8096-1b9a201af203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

