### PR TITLE
fix: narrow swapChildren playback batching for landing hero callstack

### DIFF
--- a/src/features/callstack/ui/CompactCallstackList.tsx
+++ b/src/features/callstack/ui/CompactCallstackList.tsx
@@ -29,7 +29,8 @@ export const CompactCallstackList: React.FC<CompactCallstackListProps> = ({
   const containerRef = useRef<HTMLDivElement | null>(null);
   const rowRefs = useRef<Record<string, HTMLElement | null>>({});
   const playbackStepGroups = useMemo(
-    () => getPlaybackStepGroups(callstack.frames),
+    () =>
+      getPlaybackStepGroups(callstack.frames, { forCallstackDisplay: true }),
     [callstack.frames],
   );
   const activePlaybackStepIndex = useMemo(

--- a/src/features/homePage/ui/landing/HomeLandingHeroPreviewRuntime.tsx
+++ b/src/features/homePage/ui/landing/HomeLandingHeroPreviewRuntime.tsx
@@ -95,7 +95,8 @@ const HomeLandingHeroPreviewRuntimeInner: React.FC<
   const isLastFrame = useAppSelector(selectIsLastFrame);
   const isRootFrame = useAppSelector(selectIsRootFrame);
   const playbackStepGroups = useMemo(
-    () => getPlaybackStepGroups(callstack.frames),
+    () =>
+      getPlaybackStepGroups(callstack.frames, { forCallstackDisplay: true }),
     [callstack.frames],
   );
   const activePlaybackStepIndex = useMemo(

--- a/src/features/homePage/ui/landing/HomeLandingHeroPreviewRuntime.tsx
+++ b/src/features/homePage/ui/landing/HomeLandingHeroPreviewRuntime.tsx
@@ -114,6 +114,16 @@ const HomeLandingHeroPreviewRuntimeInner: React.FC<
     }
   }, []);
 
+  // Auto-replay schedules a 900ms wait, then reset, then a short pause before setIsPlaying(true).
+  // When reset runs, `isLastFrame` becomes false and this effect re-runs; its cleanup must not clear
+  // the post-reset timeout or replay never resumes (playground-style reset sets isPlaying false).
+  const clearAutoReplayEndDelayOnly = useCallback(() => {
+    if (replayTimeoutRef.current !== null) {
+      window.clearTimeout(replayTimeoutRef.current);
+      replayTimeoutRef.current = null;
+    }
+  }, []);
+
   const stopAutoplay = () => {
     clearReplayTimers();
     hasManualOverrideRef.current = true;
@@ -177,9 +187,9 @@ const HomeLandingHeroPreviewRuntimeInner: React.FC<
       }, REPLAY_RESET_PAUSE_MS);
     }, 900);
 
-    return clearReplayTimers;
+    return clearAutoReplayEndDelayOnly;
   }, [
-    clearReplayTimers,
+    clearAutoReplayEndDelayOnly,
     dispatch,
     handleReset,
     isLastFrame,

--- a/src/features/homePage/ui/landing/__tests__/HomeLandingHeroPreviewRuntime.test.tsx
+++ b/src/features/homePage/ui/landing/__tests__/HomeLandingHeroPreviewRuntime.test.tsx
@@ -1,9 +1,10 @@
 import { configureStore } from "@reduxjs/toolkit";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { act, fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
 import { fallbackProxy } from "#/context/I18nContext";
 import { ArgumentType } from "#/entities/argument/model/argumentObject";
+import { callstackSlice } from "#/features/callstack/model/callstackSlice";
 import { HomeLandingHeroPreviewRuntime } from "#/features/homePage/ui/landing/HomeLandingHeroPreviewRuntime";
 import { StateThemeProvider } from "#/shared/ui/providers/StateThemeProvider";
 import type { RootState } from "#/store/makeStore";
@@ -103,6 +104,74 @@ describe("HomeLandingHeroPreviewRuntime", () => {
     vi.advanceTimersByTime(1200);
 
     expect(store.getState().callstack.frameIndex).toBe(-1);
+    expect(store.getState().callstack.isPlaying).toBe(true);
+
+    vi.useRealTimers();
+  });
+
+  it("auto-replay after reaching the last frame resumes playback following reset", () => {
+    vi.useFakeTimers();
+
+    const initialState = rootReducer(undefined, { type: "test/init" });
+    const store = configureStore({
+      reducer: rootReducer,
+      preloadedState: {
+        ...initialState,
+        callstack: {
+          ...initialState.callstack,
+          isReady: true,
+          isPlaying: false,
+          frameIndex: 0,
+          frames: {
+            ids: ["f1", "f2"],
+            entities: {
+              f1: {
+                id: "f1",
+                timestamp: 1,
+                name: "setVal",
+                treeName: "head",
+                nodeId: "root",
+                structureType: "treeNode",
+                argType: ArgumentType.BINARY_TREE,
+                args: { value: 1 },
+              },
+              f2: {
+                id: "f2",
+                timestamp: 2,
+                name: "setVal",
+                treeName: "head",
+                nodeId: "left",
+                structureType: "treeNode",
+                argType: ArgumentType.BINARY_TREE,
+                args: { value: 2 },
+              },
+            },
+          },
+        },
+      } satisfies RootState,
+    });
+
+    createLandingHeroPreviewStoreMock.mockReturnValueOnce(store);
+
+    render(
+      <StateThemeProvider>
+        <HomeLandingHeroPreviewRuntime LL={fallbackProxy} />
+      </StateThemeProvider>,
+    );
+
+    // TreeViewer is mocked, so simulate playback finishing at the last frame.
+    act(() => {
+      store.dispatch(callstackSlice.actions.setFrameIndex(1));
+      store.dispatch(callstackSlice.actions.setIsPlaying(false));
+    });
+
+    vi.advanceTimersByTime(900);
+
+    expect(store.getState().callstack.frameIndex).toBe(-1);
+    expect(store.getState().callstack.isPlaying).toBe(false);
+
+    vi.advanceTimersByTime(220);
+
     expect(store.getState().callstack.isPlaying).toBe(true);
 
     vi.useRealTimers();

--- a/src/features/treeViewer/hooks/__tests__/usePlayerControls.test.tsx
+++ b/src/features/treeViewer/hooks/__tests__/usePlayerControls.test.tsx
@@ -26,10 +26,17 @@ vi.mock("#/features/treeViewer/lib", async (importOriginal) => {
   });
 });
 
+type MockChildArgs = {
+  childId: string | null;
+  childTreeName?: string;
+  prevArgs?: { childId: string | null; childTreeName?: string };
+};
+
 const createMockFrame = (
   id: string,
   name: "setLeftChild" | "setRightChild" | "setVal" | "setColor" | "blink",
   nodeId: string,
+  childPointer?: MockChildArgs,
 ): CallFrame => {
   if (name === "setVal") {
     return {
@@ -77,10 +84,13 @@ const createMockFrame = (
     nodeId,
     structureType: "treeNode",
     argType: ArgumentType.BINARY_TREE,
-    args: {
+    args: childPointer ?? {
       childId: `${nodeId}-${name}`,
       childTreeName: "head",
     },
+    ...(childPointer?.prevArgs !== undefined
+      ? { prevArgs: childPointer.prevArgs }
+      : {}),
   };
 };
 
@@ -146,7 +156,10 @@ describe("usePlayerControls", () => {
   it("steps over sibling child swap pairs as one visual transition", () => {
     const frames = [
       createMockFrame("f1", "setVal", "root"),
-      createMockFrame("f2", "setLeftChild", "root"),
+      createMockFrame("f2", "setLeftChild", "root", {
+        childId: "child",
+        childTreeName: "head",
+      }),
       createMockFrame("f3", "setLeftChild", "child"),
       createMockFrame("f4", "setColor", "root"),
       createMockFrame("f5", "setRightChild", "root"),

--- a/src/features/treeViewer/lib/__tests__/playbackBatching.test.ts
+++ b/src/features/treeViewer/lib/__tests__/playbackBatching.test.ts
@@ -11,10 +11,17 @@ import {
   getPreviousPlaybackFrameIndex,
 } from "../playbackBatching";
 
+type MockChildArgs = {
+  childId: string | null;
+  childTreeName?: string;
+  prevArgs?: { childId: string | null; childTreeName?: string };
+};
+
 const createMockFrame = (
   id: string,
   name: "setLeftChild" | "setRightChild" | "setVal" | "setColor" | "blink",
   nodeId: string,
+  childPointer?: MockChildArgs,
 ): CallFrame => {
   if (name === "setVal") {
     return {
@@ -62,10 +69,13 @@ const createMockFrame = (
     nodeId,
     structureType: "treeNode",
     argType: ArgumentType.BINARY_TREE,
-    args: {
+    args: childPointer ?? {
       childId: `${nodeId}-${name}`,
       childTreeName: "head",
     },
+    ...(childPointer?.prevArgs !== undefined
+      ? { prevArgs: childPointer.prevArgs }
+      : {}),
   };
 };
 
@@ -120,20 +130,44 @@ describe("playbackBatching", () => {
     expect(getPlaybackStepIndex(groups, 3)).toBe(1);
   });
 
-  it("does not batch root swap across intervening subtree child-pointer work", () => {
+  it("batches parent swap across intervening subtree child-pointer work for playback", () => {
     const frames = [
       createMockFrame("f1", "setVal", "root"),
-      createMockFrame("f2", "setLeftChild", "root"),
+      createMockFrame("f2", "setLeftChild", "root", {
+        childId: "child",
+        childTreeName: "head",
+      }),
       createMockFrame("f3", "setLeftChild", "child"),
       createMockFrame("f4", "setColor", "child"),
       createMockFrame("f5", "setRightChild", "root"),
       createMockFrame("f6", "setVal", "tail"),
     ];
 
-    expect(getNextPlaybackFrameIndex(frames, 0)).toBe(1);
-    expect(getNextPlaybackFrameIndex(frames, 1)).toBe(2);
-    expect(getPreviousPlaybackFrameIndex(frames, 4)).toBe(3);
+    expect(getNextPlaybackFrameIndex(frames, 0)).toBe(4);
+    expect(getPreviousPlaybackFrameIndex(frames, 4)).toBe(0);
     expect(getPlaybackStepGroups(frames)).toMatchObject([
+      { kind: "single", startIndex: 0, endIndex: 0 },
+      { kind: "swap", startIndex: 1, endIndex: 4 },
+      { kind: "single", startIndex: 5, endIndex: 5 },
+    ]);
+  });
+
+  it("splits that sequence for compact callstack display", () => {
+    const frames = [
+      createMockFrame("f1", "setVal", "root"),
+      createMockFrame("f2", "setLeftChild", "root", {
+        childId: "child",
+        childTreeName: "head",
+      }),
+      createMockFrame("f3", "setLeftChild", "child"),
+      createMockFrame("f4", "setColor", "child"),
+      createMockFrame("f5", "setRightChild", "root"),
+      createMockFrame("f6", "setVal", "tail"),
+    ];
+
+    expect(
+      getPlaybackStepGroups(frames, { forCallstackDisplay: true }),
+    ).toMatchObject([
       { kind: "single", startIndex: 0, endIndex: 0 },
       { kind: "single", startIndex: 1, endIndex: 1 },
       { kind: "single", startIndex: 2, endIndex: 2 },
@@ -143,10 +177,33 @@ describe("playbackBatching", () => {
     ]);
   });
 
+  it("wide playback still batches when left clear uses prevArgs child id (detach subtree)", () => {
+    const frames = [
+      createMockFrame("f1", "setVal", "root"),
+      createMockFrame("f2", "setLeftChild", "root", {
+        childId: null,
+        childTreeName: "head",
+        prevArgs: { childId: "sub", childTreeName: "head" },
+      }),
+      createMockFrame("f3", "setLeftChild", "sub"),
+      createMockFrame("f4", "setRightChild", "root"),
+      createMockFrame("f5", "setVal", "tail"),
+    ];
+
+    expect(getPlaybackStepGroups(frames)).toMatchObject([
+      { kind: "single", startIndex: 0, endIndex: 0 },
+      { kind: "swap", startIndex: 1, endIndex: 3 },
+      { kind: "single", startIndex: 4, endIndex: 4 },
+    ]);
+  });
+
   it("does not batch across another node's child-pointer between sibling setters", () => {
     const frames = [
       createMockFrame("f1", "setVal", "root"),
-      createMockFrame("f2", "setLeftChild", "root"),
+      createMockFrame("f2", "setLeftChild", "root", {
+        childId: "left-node",
+        childTreeName: "head",
+      }),
       createMockFrame("f3", "setLeftChild", "other"),
       createMockFrame("f4", "setRightChild", "root"),
       createMockFrame("f5", "setVal", "tail"),

--- a/src/features/treeViewer/lib/__tests__/playbackBatching.test.ts
+++ b/src/features/treeViewer/lib/__tests__/playbackBatching.test.ts
@@ -106,45 +106,7 @@ describe("playbackBatching", () => {
 
     expect(getNextPlaybackFrameIndex(frames, 0)).toBe(4);
     expect(getPreviousPlaybackFrameIndex(frames, 4)).toBe(0);
-    expect(getPlaybackStepGroups(frames)).toMatchObject([
-      { kind: "single", startIndex: 0, endIndex: 0 },
-      { kind: "swap", startIndex: 1, endIndex: 4 },
-      { kind: "single", startIndex: 5, endIndex: 5 },
-    ]);
-    expect(getPlaybackStepIndex(getPlaybackStepGroups(frames), 3)).toBe(1);
-  });
-
-  it("keeps the swap grouped across intervening subtree structural work", () => {
-    const frames = [
-      createMockFrame("f1", "setVal", "root"),
-      createMockFrame("f2", "setLeftChild", "root"),
-      createMockFrame("f3", "setLeftChild", "child"),
-      createMockFrame("f4", "setColor", "child"),
-      createMockFrame("f5", "setRightChild", "root"),
-      createMockFrame("f6", "setVal", "tail"),
-    ];
-
-    expect(getNextPlaybackFrameIndex(frames, 0)).toBe(4);
-    expect(getPreviousPlaybackFrameIndex(frames, 4)).toBe(0);
-    expect(getPlaybackStepGroups(frames)).toMatchObject([
-      { kind: "single", startIndex: 0, endIndex: 0 },
-      { kind: "swap", startIndex: 1, endIndex: 4 },
-      { kind: "single", startIndex: 5, endIndex: 5 },
-    ]);
-  });
-
-  it("keeps the actual sibling setter as the swap partner", () => {
-    const frames = [
-      createMockFrame("f1", "setVal", "root"),
-      createMockFrame("f2", "setLeftChild", "root"),
-      createMockFrame("f3", "setRightChild", "child"),
-      createMockFrame("f4", "setColor", "child"),
-      createMockFrame("f5", "setRightChild", "root"),
-      createMockFrame("f6", "setVal", "tail"),
-    ];
-
     const groups = getPlaybackStepGroups(frames);
-
     expect(groups).toMatchObject([
       { kind: "single", startIndex: 0, endIndex: 0 },
       { kind: "swap", startIndex: 1, endIndex: 4 },
@@ -155,5 +117,47 @@ describe("playbackBatching", () => {
       primaryFrame: { id: "f2", nodeId: "root", name: "setLeftChild" },
       partnerFrame: { id: "f5", nodeId: "root", name: "setRightChild" },
     });
+    expect(getPlaybackStepIndex(groups, 3)).toBe(1);
+  });
+
+  it("does not batch root swap across intervening subtree child-pointer work", () => {
+    const frames = [
+      createMockFrame("f1", "setVal", "root"),
+      createMockFrame("f2", "setLeftChild", "root"),
+      createMockFrame("f3", "setLeftChild", "child"),
+      createMockFrame("f4", "setColor", "child"),
+      createMockFrame("f5", "setRightChild", "root"),
+      createMockFrame("f6", "setVal", "tail"),
+    ];
+
+    expect(getNextPlaybackFrameIndex(frames, 0)).toBe(1);
+    expect(getNextPlaybackFrameIndex(frames, 1)).toBe(2);
+    expect(getPreviousPlaybackFrameIndex(frames, 4)).toBe(3);
+    expect(getPlaybackStepGroups(frames)).toMatchObject([
+      { kind: "single", startIndex: 0, endIndex: 0 },
+      { kind: "single", startIndex: 1, endIndex: 1 },
+      { kind: "single", startIndex: 2, endIndex: 2 },
+      { kind: "single", startIndex: 3, endIndex: 3 },
+      { kind: "single", startIndex: 4, endIndex: 4 },
+      { kind: "single", startIndex: 5, endIndex: 5 },
+    ]);
+  });
+
+  it("does not batch across another node's child-pointer between sibling setters", () => {
+    const frames = [
+      createMockFrame("f1", "setVal", "root"),
+      createMockFrame("f2", "setLeftChild", "root"),
+      createMockFrame("f3", "setLeftChild", "other"),
+      createMockFrame("f4", "setRightChild", "root"),
+      createMockFrame("f5", "setVal", "tail"),
+    ];
+
+    expect(getPlaybackStepGroups(frames)).toMatchObject([
+      { kind: "single", startIndex: 0, endIndex: 0 },
+      { kind: "single", startIndex: 1, endIndex: 1 },
+      { kind: "single", startIndex: 2, endIndex: 2 },
+      { kind: "single", startIndex: 3, endIndex: 3 },
+      { kind: "single", startIndex: 4, endIndex: 4 },
+    ]);
   });
 });

--- a/src/features/treeViewer/lib/index.ts
+++ b/src/features/treeViewer/lib/index.ts
@@ -2,6 +2,7 @@ export { computeZoomAtPoint, type ViewTransform } from "./zoomAtPoint";
 export {
   getLastRenderableFrameIndex,
   getNextPlaybackFrameIndex,
+  type GetPlaybackStepGroupsOptions,
   type PlaybackStepGroup,
   getPlaybackStepGroups,
   getPlaybackStepIndex,

--- a/src/features/treeViewer/lib/playbackBatching.ts
+++ b/src/features/treeViewer/lib/playbackBatching.ts
@@ -78,11 +78,41 @@ const isMatchingSwapPartnerFrame = (
 ): candidateFrame is SwapChildFrame =>
   areBatchableSwapFrames(primaryFrame, candidateFrame);
 
-const getSwapBatchPartnerIndex = (frames: CallFrame[], startIndex: number) => {
+/** Node ids touched by the start frame's child pointer (for wide swap batching). */
+const getRelatedChildNodeIds = (frame: SwapChildFrame): Set<string> => {
+  const ids = new Set<string>();
+  if (frame.args.childId) {
+    ids.add(frame.args.childId);
+  }
+  if (frame.prevArgs?.childId) {
+    ids.add(frame.prevArgs.childId);
+  }
+  return ids;
+};
+
+export type GetPlaybackStepGroupsOptions = {
+  /**
+   * When true, stop at any other `setLeftChild` / `setRightChild` before the partner
+   * so each subtree pointer step is its own row (compact callstack / landing preview list).
+   * When false (default), only stop on a repeat same-side setter on the same node so a
+   * parent swap can span descendant detach/reattach work (single playback step).
+   */
+  forCallstackDisplay?: boolean;
+};
+
+const getSwapBatchPartnerIndex = (
+  frames: CallFrame[],
+  startIndex: number,
+  stopAtForeignSwapChild: boolean,
+) => {
   const startFrame = frames[startIndex];
   if (!isSwapChildFrame(startFrame)) {
     return startIndex;
   }
+
+  const relatedChildNodeIds = stopAtForeignSwapChild
+    ? null
+    : getRelatedChildNodeIds(startFrame);
 
   for (let index = startIndex + 1; index < frames.length; index += 1) {
     const frame = frames[index];
@@ -94,11 +124,25 @@ const getSwapBatchPartnerIndex = (frames: CallFrame[], startIndex: number) => {
       return index;
     }
 
-    // Do not batch across other child-pointer updates (different node or same side).
-    // Those are separate logical steps and should appear as their own playback rows
-    // (e.g. landing hero preview: subtree detach work between root L/R must stay visible).
     if (isSwapChildFrame(frame)) {
-      break;
+      if (
+        frame.treeName === startFrame.treeName &&
+        frame.nodeId === startFrame.nodeId &&
+        frame.structureType === startFrame.structureType &&
+        frame.name === startFrame.name
+      ) {
+        break;
+      }
+      if (stopAtForeignSwapChild) {
+        break;
+      }
+      if (
+        relatedChildNodeIds &&
+        relatedChildNodeIds.size > 0 &&
+        !relatedChildNodeIds.has(frame.nodeId)
+      ) {
+        break;
+      }
     }
   }
 
@@ -148,8 +192,10 @@ export const getPreviousPlaybackFrameIndex = (
 
 export const getPlaybackStepGroups = (
   frames: CallFrame[],
+  options?: GetPlaybackStepGroupsOptions,
 ): PlaybackStepGroup[] => {
   const groups: PlaybackStepGroup[] = [];
+  const stopAtForeignSwapChild = Boolean(options?.forCallstackDisplay);
 
   for (let index = 0; index < frames.length; ) {
     const startIndex = getNextRenderableFrameIndex(frames, index - 1);
@@ -163,7 +209,11 @@ export const getPlaybackStepGroups = (
       continue;
     }
 
-    const endIndex = getSwapBatchPartnerIndex(frames, startIndex);
+    const endIndex = getSwapBatchPartnerIndex(
+      frames,
+      startIndex,
+      stopAtForeignSwapChild,
+    );
 
     if (endIndex > startIndex && isSwapChildFrame(primaryFrame)) {
       const groupFrames = frames

--- a/src/features/treeViewer/lib/playbackBatching.ts
+++ b/src/features/treeViewer/lib/playbackBatching.ts
@@ -94,13 +94,10 @@ const getSwapBatchPartnerIndex = (frames: CallFrame[], startIndex: number) => {
       return index;
     }
 
-    if (
-      isSwapChildFrame(frame) &&
-      frame.treeName === startFrame.treeName &&
-      frame.nodeId === startFrame.nodeId &&
-      frame.structureType === startFrame.structureType &&
-      frame.name === startFrame.name
-    ) {
+    // Do not batch across other child-pointer updates (different node or same side).
+    // Those are separate logical steps and should appear as their own playback rows
+    // (e.g. landing hero preview: subtree detach work between root L/R must stay visible).
+    if (isSwapChildFrame(frame)) {
       break;
     }
   }

--- a/src/features/treeViewer/ui/NodesView.tsx
+++ b/src/features/treeViewer/ui/NodesView.tsx
@@ -61,17 +61,24 @@ export const NodesView: React.FC<NodesViewProps> = ({
       return baseLeft;
     }
 
-    const minX = Math.min(...nodes.map((node) => node.x));
-    const maxX = Math.max(...nodes.map((node) => node.x));
-    const treeCenterX = (minX + maxX + NODE_WIDTH) / 2;
+    // Anchor to the root so the tree does not drift horizontally when the bbox
+    // narrows (e.g. left subtree moves in); min/max centering shifts the whole tree each step.
+    const rootNode = data.rootId ? data.nodes.entities[data.rootId] : undefined;
+    const anchorCenterX = rootNode
+      ? rootNode.x + NODE_WIDTH / 2
+      : (() => {
+          const minX = Math.min(...nodes.map((node) => node.x));
+          const maxX = Math.max(...nodes.map((node) => node.x));
+          return (minX + maxX + NODE_WIDTH) / 2;
+        })();
 
     if (baseLeft === 0) {
-      return `calc(50% - ${treeCenterX}px)`;
+      return `calc(50% - ${anchorCenterX}px)`;
     }
 
     const leftSign = baseLeft >= 0 ? "+" : "-";
-    return `calc(50% ${leftSign} ${Math.abs(baseLeft)}px - ${treeCenterX}px)`;
-  }, [data.nodes.entities, data.type, horizontalAlign, offset, style?.left]);
+    return `calc(50% ${leftSign} ${Math.abs(baseLeft)}px - ${anchorCenterX}px)`;
+  }, [data, horizontalAlign, offset, style?.left]);
 
   return (
     <Box


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

### Swap batching: playback vs compact UI

Playback (`useNodesRuntimeUpdates`, step forward/back, `getNextPlaybackFrameIndex`) needs **one step** to cover a parent swap even when the runtime inserts subtree `setLeftChild` / `setRightChild` between the parent’s L and R updates. The compact callstack and landing hero should still **list every structural frame** on its own row.

**Change:** `getPlaybackStepGroups(frames, options?)` accepts `{ forCallstackDisplay: true }` for strict grouping (break at any foreign child-pointer). Default (playback) skips foreign child-pointer frames only when they are **not** on a node id in `args.childId` / `prevArgs.childId` of the starting setter—so detach-to-null with `prevArgs.childId` still ties subtree work to the parent swap. Unrelated nodes (e.g. `other` between root L/R) still break playback batching.

`CompactCallstackList` and hero step counter use `forCallstackDisplay: true`. `useNodesRuntimeUpdates` uses default (wide) grouping.

### Other fixes on this PR

- Landing hero swap batching visibility (narrow display grouping).
- Hero auto-replay after reset (do not clear post-reset timeout in effect cleanup).
- Centered binary tree anchored to root to avoid horizontal drift when bbox narrows.

## Tests

- `playbackBatching` covers wide vs display modes, prevArgs child id, and unrelated-node break.
- Hero preview and `useNodesRuntimeUpdates` tests pass.

`pnpm lint` / targeted vitest runs pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c9aedc72-4776-4ff8-bda2-5832bf090b5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c9aedc72-4776-4ff8-bda2-5832bf090b5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

