### PR TITLE
fix(theme): align input autofill with obsidian surfaces

### DIFF
--- a/src/themes.ts
+++ b/src/themes.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PaletteColor } from "@mui/material";
-import { alpha, createTheme } from "@mui/material/styles";
+import { alpha, createTheme, type Theme } from "@mui/material/styles";
 
 import type { Difficulty } from "#/graphql/generated";
 
@@ -66,6 +66,57 @@ const queryMatchesViewport = (query: string, viewportWidth: number) => {
 const createSsrMatchMedia = (deviceType: SsrDeviceType) => (query: string) => ({
   matches: queryMatchesViewport(query, getViewportWidth(deviceType)),
 });
+
+/** MUI uses a hardcoded #266798 autofill inset in dark mode; we match obsidian surfaces instead. */
+const webkitAutofillInsetShadow = (fillColor: string) =>
+  `0 0 0 100px ${fillColor} inset`;
+
+type WebkitAutofillBorderRadii =
+  | { borderRadius: "inherit" }
+  | {
+      borderTopLeftRadius: "inherit";
+      borderTopRightRadius: "inherit";
+    };
+
+const webkitAutofillChrome = (
+  fillColor: string,
+  radii: WebkitAutofillBorderRadii,
+) => ({
+  WebkitBoxShadow: webkitAutofillInsetShadow(fillColor),
+  WebkitTextFillColor: obsidianTokens.textPrimary,
+  caretColor: obsidianTokens.textPrimary,
+  ...radii,
+});
+
+/**
+ * Mirrors MUI's split between legacy palette.mode and cssVariables + getColorSchemeSelector("dark").
+ */
+const darkModeInputWebkitAutofillOverrides = (
+  muiTheme: Theme,
+  fillColor: string,
+  borderRadii: WebkitAutofillBorderRadii,
+) => {
+  const autofillBlock = {
+    "&:-webkit-autofill": webkitAutofillChrome(fillColor, borderRadii),
+  };
+
+  if (
+    muiTheme.vars &&
+    "getColorSchemeSelector" in muiTheme &&
+    typeof muiTheme.getColorSchemeSelector === "function"
+  ) {
+    return {
+      "&:-webkit-autofill": borderRadii,
+      [muiTheme.getColorSchemeSelector("dark")]: autofillBlock,
+    };
+  }
+
+  if (muiTheme.palette.mode === "dark") {
+    return autofillBlock;
+  }
+
+  return {};
+};
 
 export const createCustomTheme = (deviceType: SsrDeviceType = "desktop") => {
   const theme = createTheme({
@@ -287,65 +338,25 @@ export const createCustomTheme = (deviceType: SsrDeviceType = "desktop") => {
               borderColor: alpha(obsidianTokens.accentSoft, 0.7),
             },
           },
-          // MUI defaults to a hardcoded #266798 autofill inset in dark mode; match app surfaces instead.
-          input: ({ theme: muiTheme }) => ({
-            ...(!muiTheme.vars && muiTheme.palette.mode === "dark"
-              ? {
-                  "&:-webkit-autofill": {
-                    WebkitBoxShadow: `0 0 0 100px ${obsidianTokens.surfaceLowest} inset`,
-                    WebkitTextFillColor: obsidianTokens.textPrimary,
-                    caretColor: obsidianTokens.textPrimary,
-                    borderRadius: "inherit",
-                  },
-                }
-              : {}),
-            ...(muiTheme.vars
-              ? {
-                  "&:-webkit-autofill": {
-                    borderRadius: "inherit",
-                  },
-                  [muiTheme.getColorSchemeSelector("dark")]: {
-                    "&:-webkit-autofill": {
-                      WebkitBoxShadow: `0 0 0 100px ${obsidianTokens.surfaceLowest} inset`,
-                      WebkitTextFillColor: obsidianTokens.textPrimary,
-                      caretColor: obsidianTokens.textPrimary,
-                    },
-                  },
-                }
-              : {}),
-          }),
+          input: ({ theme: muiTheme }) =>
+            darkModeInputWebkitAutofillOverrides(
+              muiTheme,
+              obsidianTokens.surfaceLowest,
+              { borderRadius: "inherit" },
+            ),
         },
       },
       MuiFilledInput: {
         styleOverrides: {
-          input: ({ theme: muiTheme }) => ({
-            ...(!muiTheme.vars && muiTheme.palette.mode === "dark"
-              ? {
-                  "&:-webkit-autofill": {
-                    WebkitBoxShadow: `0 0 0 100px ${alpha(obsidianTokens.surfaceLow, 0.98)} inset`,
-                    WebkitTextFillColor: obsidianTokens.textPrimary,
-                    caretColor: obsidianTokens.textPrimary,
-                    borderTopLeftRadius: "inherit",
-                    borderTopRightRadius: "inherit",
-                  },
-                }
-              : {}),
-            ...(muiTheme.vars
-              ? {
-                  "&:-webkit-autofill": {
-                    borderTopLeftRadius: "inherit",
-                    borderTopRightRadius: "inherit",
-                  },
-                  [muiTheme.getColorSchemeSelector("dark")]: {
-                    "&:-webkit-autofill": {
-                      WebkitBoxShadow: `0 0 0 100px ${alpha(obsidianTokens.surfaceLow, 0.98)} inset`,
-                      WebkitTextFillColor: obsidianTokens.textPrimary,
-                      caretColor: obsidianTokens.textPrimary,
-                    },
-                  },
-                }
-              : {}),
-          }),
+          input: ({ theme: muiTheme }) =>
+            darkModeInputWebkitAutofillOverrides(
+              muiTheme,
+              alpha(obsidianTokens.surfaceLow, 0.98),
+              {
+                borderTopLeftRadius: "inherit",
+                borderTopRightRadius: "inherit",
+              },
+            ),
         },
       },
     },

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -287,6 +287,65 @@ export const createCustomTheme = (deviceType: SsrDeviceType = "desktop") => {
               borderColor: alpha(obsidianTokens.accentSoft, 0.7),
             },
           },
+          // MUI defaults to a hardcoded #266798 autofill inset in dark mode; match app surfaces instead.
+          input: ({ theme: muiTheme }) => ({
+            ...(!muiTheme.vars && muiTheme.palette.mode === "dark"
+              ? {
+                  "&:-webkit-autofill": {
+                    WebkitBoxShadow: `0 0 0 100px ${obsidianTokens.surfaceLowest} inset`,
+                    WebkitTextFillColor: obsidianTokens.textPrimary,
+                    caretColor: obsidianTokens.textPrimary,
+                    borderRadius: "inherit",
+                  },
+                }
+              : {}),
+            ...(muiTheme.vars
+              ? {
+                  "&:-webkit-autofill": {
+                    borderRadius: "inherit",
+                  },
+                  [muiTheme.getColorSchemeSelector("dark")]: {
+                    "&:-webkit-autofill": {
+                      WebkitBoxShadow: `0 0 0 100px ${obsidianTokens.surfaceLowest} inset`,
+                      WebkitTextFillColor: obsidianTokens.textPrimary,
+                      caretColor: obsidianTokens.textPrimary,
+                    },
+                  },
+                }
+              : {}),
+          }),
+        },
+      },
+      MuiFilledInput: {
+        styleOverrides: {
+          input: ({ theme: muiTheme }) => ({
+            ...(!muiTheme.vars && muiTheme.palette.mode === "dark"
+              ? {
+                  "&:-webkit-autofill": {
+                    WebkitBoxShadow: `0 0 0 100px ${alpha(obsidianTokens.surfaceLow, 0.98)} inset`,
+                    WebkitTextFillColor: obsidianTokens.textPrimary,
+                    caretColor: obsidianTokens.textPrimary,
+                    borderTopLeftRadius: "inherit",
+                    borderTopRightRadius: "inherit",
+                  },
+                }
+              : {}),
+            ...(muiTheme.vars
+              ? {
+                  "&:-webkit-autofill": {
+                    borderTopLeftRadius: "inherit",
+                    borderTopRightRadius: "inherit",
+                  },
+                  [muiTheme.getColorSchemeSelector("dark")]: {
+                    "&:-webkit-autofill": {
+                      WebkitBoxShadow: `0 0 0 100px ${alpha(obsidianTokens.surfaceLow, 0.98)} inset`,
+                      WebkitTextFillColor: obsidianTokens.textPrimary,
+                      caretColor: obsidianTokens.textPrimary,
+                    },
+                  },
+                }
+              : {}),
+          }),
         },
       },
     },

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -89,34 +89,20 @@ const webkitAutofillChrome = (
 });
 
 /**
- * Mirrors MUI's split between legacy palette.mode and cssVariables + getColorSchemeSelector("dark").
+ * Override MUI's hardcoded #266798 autofill inset on dark inputs.
+ *
+ * With a single dark `colorScheme`, MUI's `getColorSchemeSelector("dark")` resolves to `"&"`.
+ * Nesting `&` + `&:-webkit-autofill` then breaks the generated selector, so overrides never apply.
+ * Using `palette.mode === "dark"` matches our app (dark-only) and fixes that case.
  */
 const darkModeInputWebkitAutofillOverrides = (
   muiTheme: Theme,
   fillColor: string,
   borderRadii: WebkitAutofillBorderRadii,
-) => {
-  const autofillBlock = {
-    "&:-webkit-autofill": webkitAutofillChrome(fillColor, borderRadii),
-  };
-
-  if (
-    muiTheme.vars &&
-    "getColorSchemeSelector" in muiTheme &&
-    typeof muiTheme.getColorSchemeSelector === "function"
-  ) {
-    return {
-      "&:-webkit-autofill": borderRadii,
-      [muiTheme.getColorSchemeSelector("dark")]: autofillBlock,
-    };
-  }
-
-  if (muiTheme.palette.mode === "dark") {
-    return autofillBlock;
-  }
-
-  return {};
-};
+) =>
+  muiTheme.palette.mode === "dark"
+    ? { "&:-webkit-autofill": webkitAutofillChrome(fillColor, borderRadii) }
+    : {};
 
 export const createCustomTheme = (deviceType: SsrDeviceType = "desktop") => {
   const theme = createTheme({

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -1,7 +1,7 @@
 "use client";
 
 import type { PaletteColor } from "@mui/material";
-import { alpha, createTheme, type Theme } from "@mui/material/styles";
+import { alpha, createTheme } from "@mui/material/styles";
 
 import type { Difficulty } from "#/graphql/generated";
 
@@ -67,42 +67,12 @@ const createSsrMatchMedia = (deviceType: SsrDeviceType) => (query: string) => ({
   matches: queryMatchesViewport(query, getViewportWidth(deviceType)),
 });
 
-/** MUI uses a hardcoded #266798 autofill inset in dark mode; we match obsidian surfaces instead. */
-const webkitAutofillInsetShadow = (fillColor: string) =>
-  `0 0 0 100px ${fillColor} inset`;
-
-type WebkitAutofillBorderRadii =
-  | { borderRadius: "inherit" }
-  | {
-      borderTopLeftRadius: "inherit";
-      borderTopRightRadius: "inherit";
-    };
-
-const webkitAutofillChrome = (
-  fillColor: string,
-  radii: WebkitAutofillBorderRadii,
-) => ({
-  WebkitBoxShadow: webkitAutofillInsetShadow(fillColor),
+/** MUI dark mode uses a #266798 autofill inset; transparent avoids the blue wash with any surface. */
+const webkitAutofillTransparent = {
+  WebkitBoxShadow: "0 0 0 100px transparent inset",
   WebkitTextFillColor: obsidianTokens.textPrimary,
   caretColor: obsidianTokens.textPrimary,
-  ...radii,
-});
-
-/**
- * Override MUI's hardcoded #266798 autofill inset on dark inputs.
- *
- * With a single dark `colorScheme`, MUI's `getColorSchemeSelector("dark")` resolves to `"&"`.
- * Nesting `&` + `&:-webkit-autofill` then breaks the generated selector, so overrides never apply.
- * Using `palette.mode === "dark"` matches our app (dark-only) and fixes that case.
- */
-const darkModeInputWebkitAutofillOverrides = (
-  muiTheme: Theme,
-  fillColor: string,
-  borderRadii: WebkitAutofillBorderRadii,
-) =>
-  muiTheme.palette.mode === "dark"
-    ? { "&:-webkit-autofill": webkitAutofillChrome(fillColor, borderRadii) }
-    : {};
+} as const;
 
 export const createCustomTheme = (deviceType: SsrDeviceType = "desktop") => {
   const theme = createTheme({
@@ -313,7 +283,7 @@ export const createCustomTheme = (deviceType: SsrDeviceType = "desktop") => {
       MuiOutlinedInput: {
         styleOverrides: {
           root: {
-            backgroundColor: obsidianTokens.surfaceLowest,
+            backgroundColor: "transparent",
             "& fieldset": {
               borderColor: alpha(obsidianTokens.outline, 0.14),
             },
@@ -324,25 +294,38 @@ export const createCustomTheme = (deviceType: SsrDeviceType = "desktop") => {
               borderColor: alpha(obsidianTokens.accentSoft, 0.7),
             },
           },
-          input: ({ theme: muiTheme }) =>
-            darkModeInputWebkitAutofillOverrides(
-              muiTheme,
-              obsidianTokens.surfaceLowest,
-              { borderRadius: "inherit" },
-            ),
+          input: {
+            "&:-webkit-autofill": {
+              ...webkitAutofillTransparent,
+              borderRadius: "inherit",
+            },
+          },
         },
       },
       MuiFilledInput: {
         styleOverrides: {
-          input: ({ theme: muiTheme }) =>
-            darkModeInputWebkitAutofillOverrides(
-              muiTheme,
-              alpha(obsidianTokens.surfaceLow, 0.98),
-              {
-                borderTopLeftRadius: "inherit",
-                borderTopRightRadius: "inherit",
+          root: {
+            backgroundColor: "transparent",
+            "&:hover": {
+              backgroundColor: "transparent",
+              "@media (hover: none)": {
+                backgroundColor: "transparent",
               },
-            ),
+            },
+            "&.Mui-focused": {
+              backgroundColor: "transparent",
+            },
+            "&.Mui-disabled": {
+              backgroundColor: "transparent",
+            },
+          },
+          input: {
+            "&:-webkit-autofill": {
+              ...webkitAutofillTransparent,
+              borderTopLeftRadius: "inherit",
+              borderTopRightRadius: "inherit",
+            },
+          },
         },
       },
     },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Text fields showed an odd **dark blue** wash from MUI’s default `:-webkit-autofill` handling (`#266798` inset) and/or filled input backgrounds.

## Changes

- **`MuiOutlinedInput`**: `root` `backgroundColor` is **`transparent`** so outlined fields show the parent surface; no separate input “panel” color.
- **`:-webkit-autofill`**: use **`WebkitBoxShadow: 0 0 0 100px transparent inset`** plus `textPrimary` for fill/caret (no color-matching logic, works regardless of selector quirks).
- **`MuiFilledInput`**: root background forced **transparent** across default, hover, focus, and disabled so filled variant also blends with the parent (if used).

## Testing

- `pnpm run tsc` passes.
- `eslint src/themes.ts` passes.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-981eb646-be75-4a98-af8d-f3e4b1853ba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-981eb646-be75-4a98-af8d-f3e4b1853ba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

