### PR TITLE
fix(home): mobile hero preview alignment and IconButton backgrounds

### DIFF
--- a/src/features/homePage/ui/landing/HomeLandingHeroPreview.tsx
+++ b/src/features/homePage/ui/landing/HomeLandingHeroPreview.tsx
@@ -48,7 +48,7 @@ export const HomeLandingHeroPreview: React.FC<HomeLandingHeroPreviewProps> = ({
         direction={{ xs: "column", sm: "row" }}
         spacing={1.25}
         justifyContent="space-between"
-        alignItems={{ xs: "flex-start", sm: "center" }}
+        alignItems={{ xs: "stretch", sm: "center" }}
         sx={{
           p: 1.5,
           borderBottom: `1px solid ${alpha(theme.appDesign.outline, 0.14)}`,
@@ -56,7 +56,12 @@ export const HomeLandingHeroPreview: React.FC<HomeLandingHeroPreviewProps> = ({
           rowGap: 1.25,
         }}
       >
-        <Stack direction="row" spacing={1} alignItems="center">
+        <Stack
+          direction="row"
+          spacing={1}
+          alignItems="center"
+          justifyContent={{ xs: "center", sm: "flex-start" }}
+        >
           {WINDOW_CONTROLS.map((color) => (
             <Box
               key={color}
@@ -73,6 +78,7 @@ export const HomeLandingHeroPreview: React.FC<HomeLandingHeroPreviewProps> = ({
         <Stack
           direction="row"
           spacing={1}
+          justifyContent="flex-end"
           sx={{
             flexWrap: "wrap",
             rowGap: 1,

--- a/src/features/homePage/ui/landing/HomeLandingHeroPreviewRuntime.tsx
+++ b/src/features/homePage/ui/landing/HomeLandingHeroPreviewRuntime.tsx
@@ -12,7 +12,6 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
-import type { Theme } from "@mui/material/styles";
 import React, {
   useCallback,
   useEffect,
@@ -52,32 +51,6 @@ type HomeLandingHeroPreviewRuntimeProps = {
 
 const PLAYBACK_INTERVAL_MS = 300;
 const REPLAY_RESET_PAUSE_MS = 220;
-
-const landingPreviewCircleIconButtonSx = (muiTheme: Theme) => ({
-  "&:hover": {
-    bgcolor: alpha(muiTheme.appDesign.surfaceHigh, 0.95),
-  },
-  "&.Mui-focusVisible": {
-    bgcolor: alpha(muiTheme.appDesign.surfaceHigh, 0.9),
-  },
-  "&:active": {
-    bgcolor: alpha(muiTheme.appDesign.surfaceHigh, 0.85),
-  },
-});
-
-const landingPreviewPlayIconButtonSx = (muiTheme: Theme) => ({
-  bgcolor: alpha(muiTheme.appDesign.accent, 0.14),
-  color: muiTheme.appDesign.accentSoft,
-  "&:hover": {
-    bgcolor: alpha(muiTheme.appDesign.accent, 0.22),
-  },
-  "&.Mui-focusVisible": {
-    bgcolor: alpha(muiTheme.appDesign.accent, 0.18),
-  },
-  "&:active": {
-    bgcolor: alpha(muiTheme.appDesign.accent, 0.26),
-  },
-});
 
 type LandingHeroPreviewRuntimeState =
   | {
@@ -328,7 +301,6 @@ const HomeLandingHeroPreviewRuntimeInner: React.FC<
             title={LL.HOME_PREVIEW_STEP_BACK()}
             sx={{
               bgcolor: alpha(theme.appDesign.surfaceHigh, 0.9),
-              ...landingPreviewCircleIconButtonSx(theme),
             }}
           >
             <SkipPrevious fontSize="small" />
@@ -356,7 +328,8 @@ const HomeLandingHeroPreviewRuntimeInner: React.FC<
                   : LL.HOME_LANDING_PREVIEW_PLAY()
             }
             sx={{
-              ...landingPreviewPlayIconButtonSx(theme),
+              bgcolor: alpha(theme.appDesign.accent, 0.14),
+              color: theme.appDesign.accentSoft,
             }}
           >
             {isLastFrame && !isPlaying ? (
@@ -375,7 +348,6 @@ const HomeLandingHeroPreviewRuntimeInner: React.FC<
             title={LL.HOME_PREVIEW_STEP_FORWARD()}
             sx={{
               bgcolor: alpha(theme.appDesign.surfaceHigh, 0.9),
-              ...landingPreviewCircleIconButtonSx(theme),
             }}
           >
             <SkipNext fontSize="small" />

--- a/src/features/homePage/ui/landing/HomeLandingHeroPreviewRuntime.tsx
+++ b/src/features/homePage/ui/landing/HomeLandingHeroPreviewRuntime.tsx
@@ -12,6 +12,7 @@ import {
   Typography,
   useTheme,
 } from "@mui/material";
+import type { Theme } from "@mui/material/styles";
 import React, {
   useCallback,
   useEffect,
@@ -51,6 +52,32 @@ type HomeLandingHeroPreviewRuntimeProps = {
 
 const PLAYBACK_INTERVAL_MS = 300;
 const REPLAY_RESET_PAUSE_MS = 220;
+
+const landingPreviewCircleIconButtonSx = (muiTheme: Theme) => ({
+  "&:hover": {
+    bgcolor: alpha(muiTheme.appDesign.surfaceHigh, 0.95),
+  },
+  "&.Mui-focusVisible": {
+    bgcolor: alpha(muiTheme.appDesign.surfaceHigh, 0.9),
+  },
+  "&:active": {
+    bgcolor: alpha(muiTheme.appDesign.surfaceHigh, 0.85),
+  },
+});
+
+const landingPreviewPlayIconButtonSx = (muiTheme: Theme) => ({
+  bgcolor: alpha(muiTheme.appDesign.accent, 0.14),
+  color: muiTheme.appDesign.accentSoft,
+  "&:hover": {
+    bgcolor: alpha(muiTheme.appDesign.accent, 0.22),
+  },
+  "&.Mui-focusVisible": {
+    bgcolor: alpha(muiTheme.appDesign.accent, 0.18),
+  },
+  "&:active": {
+    bgcolor: alpha(muiTheme.appDesign.accent, 0.26),
+  },
+});
 
 type LandingHeroPreviewRuntimeState =
   | {
@@ -285,10 +312,14 @@ const HomeLandingHeroPreviewRuntimeInner: React.FC<
       <Stack
         direction={{ xs: "column", sm: "row" }}
         spacing={1}
-        alignItems={{ xs: "flex-start", sm: "center" }}
+        alignItems="center"
         sx={{ minWidth: 0 }}
       >
-        <Stack direction="row" spacing={0.5}>
+        <Stack
+          direction="row"
+          spacing={0.5}
+          justifyContent={{ xs: "flex-end", sm: "flex-start" }}
+        >
           <IconButton
             size="small"
             onClick={handleManualStepBack}
@@ -297,6 +328,7 @@ const HomeLandingHeroPreviewRuntimeInner: React.FC<
             title={LL.HOME_PREVIEW_STEP_BACK()}
             sx={{
               bgcolor: alpha(theme.appDesign.surfaceHigh, 0.9),
+              ...landingPreviewCircleIconButtonSx(theme),
             }}
           >
             <SkipPrevious fontSize="small" />
@@ -324,8 +356,7 @@ const HomeLandingHeroPreviewRuntimeInner: React.FC<
                   : LL.HOME_LANDING_PREVIEW_PLAY()
             }
             sx={{
-              bgcolor: alpha(theme.appDesign.accent, 0.14),
-              color: theme.appDesign.accentSoft,
+              ...landingPreviewPlayIconButtonSx(theme),
             }}
           >
             {isLastFrame && !isPlaying ? (
@@ -344,6 +375,7 @@ const HomeLandingHeroPreviewRuntimeInner: React.FC<
             title={LL.HOME_PREVIEW_STEP_FORWARD()}
             sx={{
               bgcolor: alpha(theme.appDesign.surfaceHigh, 0.9),
+              ...landingPreviewCircleIconButtonSx(theme),
             }}
           >
             <SkipNext fontSize="small" />
@@ -356,6 +388,7 @@ const HomeLandingHeroPreviewRuntimeInner: React.FC<
             ml: { sm: 0.5 },
             lineHeight: 1.6,
             maxWidth: { xs: "100%", sm: 220 },
+            textAlign: { xs: "right", sm: "left" },
           }}
         >
           {LL.HOME_PILLAR_VIS_BODY()}

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -242,6 +242,26 @@ export const createCustomTheme = (deviceType: SsrDeviceType = "desktop") => {
           },
         },
       },
+      MuiIconButton: {
+        styleOverrides: {
+          root: ({ theme }) => ({
+            // MUI sets backgroundColor: transparent under &:hover + @media (hover: none) for touch
+            // devices, which makes sticky :hover after a tap wipe out any custom resting bgcolor.
+            // Keep the same hover tint as fine pointers so behavior matches across form factors.
+            "&:hover": {
+              "@media (hover: none)": {
+                backgroundColor: "var(--IconButton-hoverBg)",
+              },
+            },
+            "&.Mui-focusVisible": {
+              backgroundColor: theme.palette.action.focus,
+            },
+            "&:active": {
+              backgroundColor: theme.palette.action.selected,
+            },
+          }),
+        },
+      },
       MuiChip: {
         styleOverrides: {
           root: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Mobile layout:** Preview header uses a stretched column on `xs` so rows can span full width. Traffic-light dots stay **centered**; Play / Replay / Callstack chips are **right-aligned**. Playback controls are **right-aligned** on mobile; helper caption matches.
- **Icon buttons (app-wide):** Theme `MuiIconButton` now fixes MUI’s `&:hover` + `@media (hover: none)` rule that forced **transparent** background after touch (sticky hover), so custom resting `bgcolor` is no longer wiped on mobile. **Focus-visible** uses `palette.action.focus` and **active** uses `palette.action.selected` for consistent keyboard/press feedback everywhere.
- **Landing hero:** Playback `IconButton`s only set resting `bgcolor` / `color`; hover/focus/active come from the theme like the rest of the app.

## Testing

- `pnpm exec vitest run src/features/homePage/ui/landing/__tests__/HomeLandingHeroPreviewRuntime.test.tsx`
- `pnpm exec eslint` on touched files; `tsc --noEmit`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-726e6da5-552e-4387-8f42-7097b9ff4c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-726e6da5-552e-4387-8f42-7097b9ff4c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

