### PR TITLE
fix: Google Fonts css2 URL 400 Bad Request (Roboto weight syntax)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -69,7 +69,7 @@ Refer to `package.json` scripts. Summary of most-used:
 ### Fonts (Pages Router)
 
 - **App UI:** Inter (body / default MUI typography) and Space Grotesk (headings `h1`–`h4`, `subtitle2`, app bar wordmark) load via **`next/font/google`** in `src/shared/fonts/appFonts.ts`. `pages/_document.tsx` sets `className={fontVariableClassNames}` on `<Html>` so CSS variables apply everywhere; **do not** add a duplicate Google Fonts stylesheet for those families.
-- **Stacks:** use `appFontStackSans` / `appFontStackDisplay` from `src/shared/fonts/fontVariables.ts` in theme or `sx` so names stay aligned with the loader.
+- **Stacks:** use `appFontStackSans` / `appFontStackDisplay` from `src/shared/fonts/fontVariables.ts` in theme or `sx` so names stay aligned with the loader. In `appFonts.ts`, the `next/font` `variable` option must stay **string literals** (Turbopack does not accept imported constants there).
 - **Material Icons** still use the Google Fonts icon stylesheet in `_document.tsx` (separate from text fonts).
 - **Code samples** (e.g. landing preview) intentionally use a **monospace** stack, not Inter.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,7 @@ Refer to `package.json` scripts. Summary of most-used:
 
 ### Fonts (Pages Router)
 
-- **App UI:** Inter (body / default MUI typography) and Space Grotesk (headings `h1`–`h4`, `subtitle2`, app bar wordmark) load via **`next/font/google`** in `src/shared/fonts/appFonts.ts`. `pages/_document.tsx` sets `className={fontVariableClassNames}` on `<Html>` so CSS variables apply everywhere; **do not** add a duplicate Google Fonts stylesheet for those families.
+- **App UI:** Inter (body / default MUI typography) and Space Grotesk (headings `h1`–`h4`, `subtitle2`, app bar wordmark) load via **`next/font/google`** in `src/shared/fonts/appFonts.ts`. `pages/_document.tsx` sets `className={fontVariableClassNames}` on `<Html>` (so variables inherit to `body`). **`pages/_app.tsx` must import `#/shared/fonts/appFonts`** as well — `_document` is server-only, so without that import the client bundle never gets the `@font-face` / variable rules and `var(--font-app-*)` stays undefined. **Do not** add a duplicate Google Fonts stylesheet for those families.
 - **Stacks:** use `appFontStackSans` / `appFontStackDisplay` from `src/shared/fonts/fontVariables.ts` in theme or `sx` so names stay aligned with the loader. In `appFonts.ts`, the `next/font` `variable` option must stay **string literals** (Turbopack does not accept imported constants there).
 - **Material Icons** still use the Google Fonts icon stylesheet in `_document.tsx` (separate from text fonts).
 - **Code samples** (e.g. landing preview) intentionally use a **monospace** stack, not Inter.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,15 @@ Refer to `package.json` scripts. Summary of most-used:
 - **Prisma generate**: `pnpm prisma:generate` (auto-run by `postinstall`)
 - **GraphQL codegen**: `pnpm generate-graphql` (auto-run by `postinstall`)
 
+### Fonts (Pages Router)
+
+- **App UI:** Inter (body / default MUI typography) and Space Grotesk (headings `h1`–`h4`, `subtitle2`, app bar wordmark) load via **`next/font/google`** in `src/shared/fonts/appFonts.ts`. `pages/_document.tsx` sets `className={fontVariableClassNames}` on `<Html>` so CSS variables apply everywhere; **do not** add a duplicate Google Fonts stylesheet for those families.
+- **Stacks:** use `appFontStackSans` / `appFontStackDisplay` from `src/shared/fonts/fontVariables.ts` in theme or `sx` so names stay aligned with the loader.
+- **Material Icons** still use the Google Fonts icon stylesheet in `_document.tsx` (separate from text fonts).
+- **Code samples** (e.g. landing preview) intentionally use a **monospace** stack, not Inter.
+
+Bundled Next.js reference: `node_modules/next/dist/docs/01-app/01-getting-started/13-fonts.md` (includes Pages Router `_app` examples for `next/font`).
+
 ### Gotchas
 
 - The `/api/config` endpoint uses `@vercel/edge-config` which requires Vercel's `EDGE_CONFIG` env var. It returns 404 locally but the app handles this gracefully — the playground still works fully.

--- a/src/features/appBar/ui/MainAppBar.tsx
+++ b/src/features/appBar/ui/MainAppBar.tsx
@@ -36,6 +36,7 @@ import { selectIsAppBarScrolled } from "#/features/appBar/model/appBarSlice";
 import { SidePanel } from "#/features/menuSidePanel/ui/SidePanel";
 import { useMobilePlaygroundView } from "#/features/playground/hooks/useMobilePlaygroundView";
 import { useProjectBrowserContext } from "#/features/project/ui/ProjectBrowser/ProjectBrowserContext";
+import { appFontStackDisplay } from "#/shared/fonts/fontVariables";
 import { useProfileImageUploader } from "#/shared/hooks";
 import { useI18nContext } from "#/shared/hooks";
 import { useHasMounted } from "#/shared/hooks/useHasMounted";
@@ -79,7 +80,7 @@ const LogoBrand: React.FC<{
           variant="h6"
           noWrap
           sx={{
-            fontFamily: '"Space Grotesk", "Inter", sans-serif',
+            fontFamily: appFontStackDisplay,
             fontWeight: 700,
             letterSpacing: "-0.04em",
           }}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -8,6 +8,9 @@ import { SnackbarProvider } from "notistack";
 import React from "react";
 import "symbol-observable";
 
+// `_document` is server-only; importing fonts here registers @font-face + CSS vars in the client bundle.
+import "#/shared/fonts/appFonts";
+
 import { ProjectBrowser } from "#/features/project/ui/ProjectBrowser/ProjectBrowser";
 import { ProjectBrowserProvider } from "#/features/project/ui/ProjectBrowser/ProjectBrowserContext";
 import { apolloClient } from "#/graphql/apolloClient";

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { getDocumentTextDirection } from "#/i18n/localeMeta";
 import { createEmotionCache } from "#/shared/emotion/createEmotionCache";
 import { EmotionCacheContext } from "#/shared/emotion/EmotionCacheContext";
+import { fontVariableClassNames } from "#/shared/fonts/appFonts";
 
 type MyDocumentProps = DocumentProps & {
   emotionStyleTags?: React.ReactElement;
@@ -16,7 +17,7 @@ function Document({ emotionStyleTags, htmlLang = "en" }: MyDocumentProps) {
   const dir = getDocumentTextDirection(htmlLang);
   // noinspection HtmlRequiredTitleElement
   return (
-    <Html lang={htmlLang} dir={dir}>
+    <Html lang={htmlLang} dir={dir} className={fontVariableClassNames}>
       <Head>
         {emotionStyleTags}
         <meta
@@ -54,10 +55,10 @@ function Document({ emotionStyleTags, htmlLang = "en" }: MyDocumentProps) {
         <meta name="apple-mobile-web-app-title" content="dStruct" />
 
         <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" />
         <link
-          rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Roboto:wght@300;400;500;700&family=Share+Tech&family=Space+Grotesk:wght@500;700&display=swap"
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
         />
         <link
           rel="stylesheet"

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -57,7 +57,7 @@ function Document({ emotionStyleTags, htmlLang = "en" }: MyDocumentProps) {
         <link rel="preconnect" href="https://fonts.gstatic.com" />
         <link
           rel="stylesheet"
-          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Roboto:300,400,500,700&family=Share+Tech&family=Space+Grotesk:wght@500;700&display=swap"
+          href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Roboto:wght@300;400;500;700&family=Share+Tech&family=Space+Grotesk:wght@500;700&display=swap"
         />
         <link
           rel="stylesheet"

--- a/src/shared/fonts/appFonts.ts
+++ b/src/shared/fonts/appFonts.ts
@@ -1,0 +1,21 @@
+import { Inter, Space_Grotesk } from "next/font/google";
+
+import { FONT_VAR_DISPLAY, FONT_VAR_SANS } from "#/shared/fonts/fontVariables";
+
+/** Body / UI sans — loaded via next/font (no extra Google Fonts `<link>`). */
+export const fontSans = Inter({
+  subsets: ["latin", "latin-ext", "cyrillic", "cyrillic-ext"],
+  display: "swap",
+  variable: FONT_VAR_SANS,
+});
+
+/** Display / headings — weights aligned with MUI `h1`–`h4` and `subtitle2`. */
+export const fontDisplay = Space_Grotesk({
+  weight: ["500", "700"],
+  subsets: ["latin", "latin-ext"],
+  display: "swap",
+  variable: FONT_VAR_DISPLAY,
+});
+
+/** Set on `<Html>` in `_document` so `var(--font-app-*)` resolves everywhere. */
+export const fontVariableClassNames = `${fontSans.variable} ${fontDisplay.variable}`;

--- a/src/shared/fonts/appFonts.ts
+++ b/src/shared/fonts/appFonts.ts
@@ -17,5 +17,8 @@ export const fontDisplay = Space_Grotesk({
   variable: "--font-app-display",
 });
 
-/** Set on `<Html>` in `_document` so `var(--font-app-*)` resolves everywhere. */
+/**
+ * Set on `<Html>` in `_document` so `var(--font-app-*)` inherits to `body` (globals + MUI CssBaseline).
+ * Also import this module from `_app` so Next injects font CSS on the client — `_document` alone is not enough.
+ */
 export const fontVariableClassNames = `${fontSans.variable} ${fontDisplay.variable}`;

--- a/src/shared/fonts/appFonts.ts
+++ b/src/shared/fonts/appFonts.ts
@@ -1,12 +1,12 @@
 import { Inter, Space_Grotesk } from "next/font/google";
 
-import { FONT_VAR_DISPLAY, FONT_VAR_SANS } from "#/shared/fonts/fontVariables";
-
+// `variable` must be string literals (Turbopack/next/font compile-time check).
+// Keep names in sync with `FONT_VAR_SANS` / `FONT_VAR_DISPLAY` in `fontVariables.ts`.
 /** Body / UI sans — loaded via next/font (no extra Google Fonts `<link>`). */
 export const fontSans = Inter({
   subsets: ["latin", "latin-ext", "cyrillic", "cyrillic-ext"],
   display: "swap",
-  variable: FONT_VAR_SANS,
+  variable: "--font-app-sans",
 });
 
 /** Display / headings — weights aligned with MUI `h1`–`h4` and `subtitle2`. */
@@ -14,7 +14,7 @@ export const fontDisplay = Space_Grotesk({
   weight: ["500", "700"],
   subsets: ["latin", "latin-ext"],
   display: "swap",
-  variable: FONT_VAR_DISPLAY,
+  variable: "--font-app-display",
 });
 
 /** Set on `<Html>` in `_document` so `var(--font-app-*)` resolves everywhere. */

--- a/src/shared/fonts/fontVariables.ts
+++ b/src/shared/fonts/fontVariables.ts
@@ -1,4 +1,4 @@
-/** CSS variable names; must match `variable` in `appFonts.ts` (next/font). */
+/** CSS variable names — must match literal `variable` in `appFonts.ts` (Turbopack requires literals there). */
 export const FONT_VAR_SANS = "--font-app-sans";
 export const FONT_VAR_DISPLAY = "--font-app-display";
 

--- a/src/shared/fonts/fontVariables.ts
+++ b/src/shared/fonts/fontVariables.ts
@@ -1,0 +1,9 @@
+/** CSS variable names; must match `variable` in `appFonts.ts` (next/font). */
+export const FONT_VAR_SANS = "--font-app-sans";
+export const FONT_VAR_DISPLAY = "--font-app-display";
+
+/** Body / UI stack (MUI default typography). */
+export const appFontStackSans = `var(${FONT_VAR_SANS}), system-ui, sans-serif`;
+
+/** Headings + display accents (paired with Inter). */
+export const appFontStackDisplay = `var(${FONT_VAR_DISPLAY}), var(${FONT_VAR_SANS}), system-ui, sans-serif`;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -2,18 +2,8 @@ html,
 body {
   padding: 0;
   margin: 0;
-  font-family:
-    -apple-system,
-    BlinkMacSystemFont,
-    Segoe UI,
-    Roboto,
-    Oxygen,
-    Ubuntu,
-    Cantarell,
-    Fira Sans,
-    Droid Sans,
-    Helvetica Neue,
-    sans-serif;
+  /* Matches MUI `typography.fontFamily` (Inter via next/font, see `src/shared/fonts/`). */
+  font-family: var(--font-app-sans), system-ui, sans-serif;
 }
 
 html {

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -4,6 +4,10 @@ import type { PaletteColor } from "@mui/material";
 import { alpha, createTheme } from "@mui/material/styles";
 
 import type { Difficulty } from "#/graphql/generated";
+import {
+  appFontStackDisplay,
+  appFontStackSans,
+} from "#/shared/fonts/fontVariables";
 
 export type SsrDeviceType = "mobile" | "desktop";
 
@@ -122,26 +126,26 @@ export const createCustomTheme = (deviceType: SsrDeviceType = "desktop") => {
       borderRadius: 4,
     },
     typography: {
-      fontFamily: '"Inter", "Roboto", "Helvetica", "Arial", sans-serif',
+      fontFamily: appFontStackSans,
       h1: {
-        fontFamily: '"Space Grotesk", "Inter", sans-serif',
+        fontFamily: appFontStackDisplay,
         fontWeight: 700,
         letterSpacing: "-0.04em",
         lineHeight: 1.04,
       },
       h2: {
-        fontFamily: '"Space Grotesk", "Inter", sans-serif',
+        fontFamily: appFontStackDisplay,
         fontWeight: 700,
         letterSpacing: "-0.04em",
         lineHeight: 1.08,
       },
       h3: {
-        fontFamily: '"Space Grotesk", "Inter", sans-serif',
+        fontFamily: appFontStackDisplay,
         fontWeight: 700,
         letterSpacing: "-0.035em",
       },
       h4: {
-        fontFamily: '"Space Grotesk", "Inter", sans-serif',
+        fontFamily: appFontStackDisplay,
         fontWeight: 700,
         letterSpacing: "-0.03em",
       },
@@ -154,7 +158,7 @@ export const createCustomTheme = (deviceType: SsrDeviceType = "desktop") => {
         letterSpacing: "-0.02em",
       },
       subtitle2: {
-        fontFamily: '"Space Grotesk", "Inter", sans-serif',
+        fontFamily: appFontStackDisplay,
         fontWeight: 600,
         letterSpacing: "0.05em",
         textTransform: "uppercase",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

The combined Google Fonts URL in `_document.tsx` mixed **CSS2** with legacy v1 syntax for Roboto, which returned **400 Bad Request**.

## Changes

- **Fonts:** Inter + Space Grotesk via `next/font`; Roboto / unused Share Tech removed; Material Icons link kept.
- **Turbopack:** `variable` options in `appFonts.ts` must be string literals.
- **Client fix:** Import `#/shared/fonts/appFonts` from **`pages/_app.tsx`**. `pages/_document.tsx` is **server-only**, so importing `next/font` only there did not put `@font-face` / `--font-app-*` definitions in the **client** bundle — `var(--font-app-sans)` was invalid and the UI fell back to Times New Roman.

## Verification

- `pnpm run build` — pass
- `pnpm test` — pass (earlier)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a036ba22-1f7b-4340-b93a-314f6e00d750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a036ba22-1f7b-4340-b93a-314f6e00d750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

