### PR TITLE
fix: repair load-env so postinstall succeeds

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "check:es": "es-guard",
     "dev": "next dev",
     "postinstall": "tsx src/scripts/postinstall.ts",
-    "load-env": "dotenv -e .env -e .env.local",
-    "prisma:generate": "pnpm run load-env && prisma generate && tsx prisma/scripts/generate-date-serialization.ts",
-    "prisma:push": "pnpm run load-env && prisma db push",
-    "prisma:studio": "pnpm run load-env && prisma studio",
+    "load-env": "tsx src/scripts/loadEnvAndRun.ts",
+    "prisma:generate": "pnpm run load-env -- prisma generate && tsx prisma/scripts/generate-date-serialization.ts",
+    "prisma:push": "pnpm run load-env -- prisma db push",
+    "prisma:studio": "pnpm run load-env -- prisma studio",
     "generate-graphql": "graphql-codegen --config codegen.yml",
     "tsc": "tsc --noEmit",
     "lint": "eslint . && pnpm run tsc",
@@ -31,8 +31,8 @@
     "semantic-release": "semantic-release",
     "lint-staged": "lint-staged",
     "typesafe-i18n": "typesafe-i18n",
-    "dumpAllProjects": "pnpm run load-env && cross-env NODE_ENV=development tsx src/scripts/dumpAllProjects.ts --rewrite",
-    "loadMainDump": "pnpm run load-env && cross-env NODE_ENV=development tsx src/scripts/loadProjects.ts public-dumps/main.json"
+    "dumpAllProjects": "pnpm run load-env -- cross-env NODE_ENV=development tsx src/scripts/dumpAllProjects.ts --rewrite",
+    "loadMainDump": "pnpm run load-env -- cross-env NODE_ENV=development tsx src/scripts/loadProjects.ts public-dumps/main.json"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx}": [
@@ -137,7 +137,6 @@
     "babel-plugin-react-compiler": "^1.0.0",
     "cross-env": "^10.1.0",
     "dotenv": "^17.4.0",
-    "dotenv-cli": "^11.0.0",
     "es-guard": "^1.20.0",
     "esbuild": "^0.27.7",
     "eslint": "^9.39.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,9 +294,6 @@ importers:
       dotenv:
         specifier: ^17.4.0
         version: 17.4.0
-      dotenv-cli:
-        specifier: ^11.0.0
-        version: 11.0.0
       es-guard:
         specifier: ^1.20.0
         version: 1.20.0(jiti@2.6.1)(prettier@3.8.1)
@@ -3522,14 +3519,6 @@ packages:
   dot-prop@5.3.0:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
-
-  dotenv-cli@11.0.0:
-    resolution: {integrity: sha512-r5pA8idbk7GFWuHEU7trSTflWcdBpQEK+Aw17UrSHjS6CReuhrrPcyC3zcQBPQvhArRHnBo/h6eLH1fkCvNlww==}
-    hasBin: true
-
-  dotenv-expand@12.0.3:
-    resolution: {integrity: sha512-uc47g4b+4k/M/SeaW1y4OApx+mtLWl92l5LMPP0GNXctZqELk+YGgOPIIC5elYmUH4OuoK3JLhuRUYegeySiFA==}
-    engines: {node: '>=12'}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -10225,17 +10214,6 @@ snapshots:
   dot-prop@5.3.0:
     dependencies:
       is-obj: 2.0.0
-
-  dotenv-cli@11.0.0:
-    dependencies:
-      cross-spawn: 7.0.6
-      dotenv: 17.4.0
-      dotenv-expand: 12.0.3
-      minimist: 1.2.8
-
-  dotenv-expand@12.0.3:
-    dependencies:
-      dotenv: 16.6.1
 
   dotenv@16.6.1: {}
 

--- a/src/scripts/dumpAllProjects.ts
+++ b/src/scripts/dumpAllProjects.ts
@@ -1,4 +1,4 @@
-// Environment: `pnpm run dumpAllProjects` uses dotenv-cli (`-e .env` then `-e .env.local`) so
+// Environment: `pnpm run dumpAllProjects` uses `load-env` (`loadEnvAndRun.ts`: `.env` then `.env.local`) so
 // variables exist before `tsx` runs and `#/env/server.mjs` is validated.
 import { promises as fs } from "fs";
 import minimist from "minimist";

--- a/src/scripts/loadEnvAndRun.ts
+++ b/src/scripts/loadEnvAndRun.ts
@@ -1,0 +1,46 @@
+/**
+ * Loads `.env` then `.env.local` (later overrides) into the environment and runs a shell command.
+ * Replaces `dotenv -e .env -e .env.local` without a trailing command, which exits with code 1.
+ */
+import { spawnSync } from "child_process";
+import { parse } from "dotenv";
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+
+function loadRepoEnv(): NodeJS.ProcessEnv {
+  const cwd = process.cwd();
+  const envPath = join(cwd, ".env");
+  const localPath = join(cwd, ".env.local");
+
+  const fromDotEnv = existsSync(envPath)
+    ? parse(readFileSync(envPath, "utf8"))
+    : {};
+  const fromLocal = existsSync(localPath)
+    ? parse(readFileSync(localPath, "utf8"))
+    : {};
+
+  // `.env.local` overrides `.env`; the shell / parent process overrides both.
+  return { ...fromDotEnv, ...fromLocal, ...process.env };
+}
+
+const dashIndex = process.argv.indexOf("--");
+const commandParts = dashIndex === -1 ? [] : process.argv.slice(dashIndex + 1);
+
+if (commandParts.length === 0) {
+  console.error(
+    "loadEnvAndRun: missing command after --. Example: pnpm run load-env -- prisma generate",
+  );
+  process.exit(1);
+}
+
+const command = commandParts.join(" ");
+const envWithRepoFiles = loadRepoEnv();
+
+const child = spawnSync(command, {
+  stdio: "inherit",
+  env: envWithRepoFiles,
+  shell: true,
+});
+
+const exitCode = child.status ?? 1;
+process.exit(exitCode);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

`pnpm run load-env` was defined as `dotenv -e .env -e .env.local` with **no command after `--`**. `dotenv-cli` requires a trailing command; without it it prints usage and exits **1**, which broke `prisma:generate` and therefore `postinstall`.

## Solution

- Add `src/scripts/loadEnvAndRun.ts`: merge `.env` then `.env.local` (local wins; existing `process.env` still wins over both), then run the command passed after `--` via `spawnSync` with `shell: true` so `pnpm run load-env -- prisma generate` works and propagates exit codes.
- Point `load-env` at the script and update `prisma:generate`, `prisma:push`, `prisma:studio`, `dumpAllProjects`, and `loadMainDump` to use `pnpm run load-env -- <command>`.
- Remove the unused `dotenv-cli` devDependency (lockfile updated).

## Verification

- `pnpm run prisma:generate` and full `postinstall` succeed.
- `pnpm test:ci` passes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-671b7cad-d752-425e-a3af-a4b86379f415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-671b7cad-d752-425e-a3af-a4b86379f415"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

