### PR TITLE
Fix runtime BinaryTree layout: shared tree name and root detection

### DIFF
--- a/src/entities/dataStructures/binaryTree/model/__tests__/binaryTreeNode.test.ts
+++ b/src/entities/dataStructures/binaryTree/model/__tests__/binaryTreeNode.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "vitest";
+
+import { ArgumentType } from "#/entities/argument/model/argumentObject";
+import { getRuntimeBinaryTreeClass } from "#/entities/dataStructures/binaryTree/model/binaryTreeNode";
+import {
+  type CallFrame,
+  CallstackHelper,
+} from "#/features/callstack/model/callstackSlice";
+
+const isTreeNodeFrame = (
+  frame: CallFrame,
+): frame is CallFrame & { treeName: string } => "treeName" in frame;
+
+describe("getRuntimeBinaryTreeClass", () => {
+  it("assigns the parent visualization tree name to children linked via left/right", () => {
+    const callstack = new CallstackHelper();
+    const BinaryTree = getRuntimeBinaryTreeClass(callstack);
+
+    const root = new BinaryTree(1);
+    const leftChild = new BinaryTree(2);
+    const rightChild = new BinaryTree(3);
+
+    root.left = leftChild;
+    root.right = rightChild;
+
+    const rootAddFrame = callstack.frames.find(
+      (frame) =>
+        frame.name === "addNode" && "args" in frame && frame.args.value === 1,
+    );
+    const rootTreeName =
+      rootAddFrame && isTreeNodeFrame(rootAddFrame)
+        ? rootAddFrame.treeName
+        : undefined;
+    expect(rootTreeName).toBeDefined();
+
+    callstack.clear();
+    leftChild.setColor("red");
+
+    const colorFrame = callstack.frames.find(
+      (frame) => frame.name === "setColor" && "nodeId" in frame,
+    );
+    expect(
+      colorFrame && isTreeNodeFrame(colorFrame) ? colorFrame.treeName : null,
+    ).toBe(rootTreeName);
+  });
+
+  it("wires optional constructor children through setters so they share the root tree name", () => {
+    const callstack = new CallstackHelper();
+    const BinaryTree = getRuntimeBinaryTreeClass(callstack);
+
+    const leftLeaf = new BinaryTree(2);
+    const rightLeaf = new BinaryTree(3);
+    new BinaryTree(1, leftLeaf, rightLeaf);
+
+    const rootAddFrame = callstack.frames.find(
+      (frame) =>
+        frame.name === "addNode" && "args" in frame && frame.args.value === 1,
+    );
+    const rootTreeName =
+      rootAddFrame && isTreeNodeFrame(rootAddFrame)
+        ? rootAddFrame.treeName
+        : undefined;
+    expect(rootTreeName).toBeDefined();
+
+    callstack.clear();
+    leftLeaf.setColor("cyan");
+
+    const colorFrame = callstack.frames.find(
+      (frame) => frame.name === "setColor" && "nodeId" in frame,
+    );
+    expect(
+      colorFrame && isTreeNodeFrame(colorFrame) ? colorFrame.treeName : null,
+    ).toBe(rootTreeName);
+    expect(
+      colorFrame && isTreeNodeFrame(colorFrame) ? colorFrame.argType : null,
+    ).toBe(ArgumentType.BINARY_TREE);
+  });
+});

--- a/src/entities/dataStructures/binaryTree/model/binaryTreeNode.ts
+++ b/src/entities/dataStructures/binaryTree/model/binaryTreeNode.ts
@@ -72,6 +72,9 @@ export class BinaryTreeNode<
         childTreeName: prevNode?.name,
       },
     });
+    if (node) {
+      node.name = this.name;
+    }
   }
 
   private _right!: BinaryTreeNode<T> | null;
@@ -92,6 +95,9 @@ export class BinaryTreeNode<
         childTreeName: prevNode?.name,
       },
     });
+    if (node) {
+      node.name = this.name;
+    }
   }
 
   static fromNodeData(
@@ -185,18 +191,27 @@ export const getRuntimeBinaryTreeClass = (callstack: CallstackHelper) =>
       left: BinaryTreeNode | null = null,
       right: BinaryTreeNode | null = null,
     ) {
+      const treeName = generate();
+      // Wire children via setters so the callstack (and Redux) link them under this tree; passing
+      // them into `super` would skip setters and leave each subtree in its own `treeName` bucket.
       super(
         val,
-        left,
-        right,
+        null,
+        null,
         {
           id: generate(),
           type: ArgumentType.BINARY_TREE,
           depth: 0,
         },
-        generate(),
+        treeName,
         callstack,
         true,
       );
+      if (left) {
+        this.left = left;
+      }
+      if (right) {
+        this.right = right;
+      }
     }
   };

--- a/src/entities/dataStructures/binaryTree/model/binaryTreeNode.ts
+++ b/src/entities/dataStructures/binaryTree/model/binaryTreeNode.ts
@@ -54,6 +54,13 @@ export class BinaryTreeNode<
     }
   }
 
+  /** Keep callstack/Redux `treeName` aligned with the parent so the whole tree lives in one bucket. */
+  private adoptVisualizationTreeName(child: BinaryTreeNode<T> | null): void {
+    if (child) {
+      child.name = this.name;
+    }
+  }
+
   private _left!: BinaryTreeNode<T> | null;
 
   public get left() {
@@ -72,9 +79,7 @@ export class BinaryTreeNode<
         childTreeName: prevNode?.name,
       },
     });
-    if (node) {
-      node.name = this.name;
-    }
+    this.adoptVisualizationTreeName(node);
   }
 
   private _right!: BinaryTreeNode<T> | null;
@@ -95,9 +100,7 @@ export class BinaryTreeNode<
         childTreeName: prevNode?.name,
       },
     });
-    if (node) {
-      node.name = this.name;
-    }
+    this.adoptVisualizationTreeName(node);
   }
 
   static fromNodeData(

--- a/src/entities/dataStructures/node/model/__tests__/nodeSlice.test.ts
+++ b/src/entities/dataStructures/node/model/__tests__/nodeSlice.test.ts
@@ -80,6 +80,37 @@ const createInitializedTreeState = () => {
 };
 
 describe("treeNodeSlice", () => {
+  it("sets rootId on the first runtime binary tree node add", () => {
+    let state = reduce(
+      undefined,
+      treeNodeSlice.actions.init({
+        name: TREE_NAME,
+        type: ArgumentType.BINARY_TREE,
+        order: 0,
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.add({
+        name: TREE_NAME,
+        data: createNode("root", 3),
+      }),
+    );
+
+    expect(state[TREE_NAME]?.rootId).toBe("root");
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.add({
+        name: TREE_NAME,
+        data: createNode("child", 9),
+      }),
+    );
+
+    expect(state[TREE_NAME]?.rootId).toBe("root");
+  });
+
   it("applies sibling child swaps atomically with a single childrenIds update", () => {
     const state = reduce(
       createInitializedTreeState(),

--- a/src/entities/dataStructures/node/model/__tests__/nodeSlice.test.ts
+++ b/src/entities/dataStructures/node/model/__tests__/nodeSlice.test.ts
@@ -211,6 +211,130 @@ describe("treeNodeSlice", () => {
     expect(state[TREE_NAME]?.rootId).toBe("root");
   });
 
+  it("clears rootId when the root binary tree node is removed", () => {
+    let state = reduce(
+      undefined,
+      treeNodeSlice.actions.init({
+        name: TREE_NAME,
+        type: ArgumentType.BINARY_TREE,
+        order: 0,
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.add({
+        name: TREE_NAME,
+        data: createNode("root", 3),
+      }),
+    );
+    expect(state[TREE_NAME]?.rootId).toBe("root");
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.add({
+        name: TREE_NAME,
+        data: createNode("other", 99),
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.remove({
+        name: TREE_NAME,
+        data: { id: "root" },
+      }),
+    );
+
+    expect(state[TREE_NAME]?.rootId).toBeNull();
+    expect(state[TREE_NAME]?.nodes.entities["other"]).toBeDefined();
+  });
+
+  it("leaves unrelated nodes in the source tree when moving a subtree cross-tree", () => {
+    const parentTree = "parentTree";
+    const childTree = "childTree";
+
+    let state = reduce(
+      undefined,
+      treeNodeSlice.actions.init({
+        name: parentTree,
+        type: ArgumentType.BINARY_TREE,
+        order: 0,
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.init({
+        name: childTree,
+        type: ArgumentType.BINARY_TREE,
+        order: 1,
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.addMany({
+        name: parentTree,
+        data: {
+          maxDepth: 0,
+          nodes: [createNode("root", 3)],
+        },
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.addMany({
+        name: childTree,
+        data: {
+          maxDepth: 0,
+          nodes: [
+            createNode("subroot", 20, ["leaf"]),
+            createNode("leaf", 15),
+            createNode("straggler", 99),
+          ],
+        },
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.addManyEdges({
+        name: childTree,
+        data: [
+          {
+            id: getEdgeId("subroot", "leaf"),
+            sourceId: "subroot",
+            targetId: "leaf",
+            isDirected: false,
+          },
+        ],
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.setChildId({
+        name: parentTree,
+        data: {
+          id: "root",
+          index: 0,
+          childId: "subroot",
+          childTreeName: childTree,
+        },
+      }),
+    );
+
+    const parent = state[parentTree];
+    const remaining = state[childTree];
+    expect(parent?.nodes.ids).toHaveLength(3);
+    expect(parent?.nodes.entities["straggler"]).toBeUndefined();
+    expect(remaining?.nodes.entities["straggler"]?.value).toBe(99);
+    expect(remaining?.nodes.ids).toHaveLength(1);
+    expect(remaining?.edges.ids).toHaveLength(0);
+  });
+
   it("applies sibling child swaps atomically with a single childrenIds update", () => {
     const state = reduce(
       createInitializedTreeState(),

--- a/src/entities/dataStructures/node/model/__tests__/nodeSlice.test.ts
+++ b/src/entities/dataStructures/node/model/__tests__/nodeSlice.test.ts
@@ -80,6 +80,106 @@ const createInitializedTreeState = () => {
 };
 
 describe("treeNodeSlice", () => {
+  it("moves an entire subtree when setChildId re-parents from another tree", () => {
+    const parentTree = "parentTree";
+    const childTree = "childTree";
+
+    let state = reduce(
+      undefined,
+      treeNodeSlice.actions.init({
+        name: parentTree,
+        type: ArgumentType.BINARY_TREE,
+        order: 0,
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.init({
+        name: childTree,
+        type: ArgumentType.BINARY_TREE,
+        order: 1,
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.addMany({
+        name: parentTree,
+        data: {
+          maxDepth: 0,
+          nodes: [createNode("root", 3)],
+        },
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.addMany({
+        name: childTree,
+        data: {
+          maxDepth: 0,
+          nodes: [
+            createNode("subroot", 20, ["left", "right"]),
+            createNode("left", 15),
+            createNode("right", 7),
+          ],
+        },
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.addManyEdges({
+        name: childTree,
+        data: [
+          {
+            id: getEdgeId("subroot", "left"),
+            sourceId: "subroot",
+            targetId: "left",
+            isDirected: false,
+          },
+          {
+            id: getEdgeId("subroot", "right"),
+            sourceId: "subroot",
+            targetId: "right",
+            isDirected: false,
+          },
+        ],
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.setChildId({
+        name: parentTree,
+        data: {
+          id: "root",
+          index: 1,
+          childId: "subroot",
+          childTreeName: childTree,
+        },
+      }),
+    );
+
+    const parent = state[parentTree];
+    expect(parent?.nodes.ids).toHaveLength(4);
+    expect(parent?.nodes.entities["subroot"]?.childrenIds).toEqual([
+      "left",
+      "right",
+    ]);
+    expect(parent?.nodes.entities["left"]?.value).toBe(15);
+    expect(parent?.nodes.entities["right"]?.value).toBe(7);
+    expect(parent?.edges.ids).toEqual(
+      expect.arrayContaining([
+        getEdgeId("root", "subroot"),
+        getEdgeId("subroot", "left"),
+        getEdgeId("subroot", "right"),
+      ]),
+    );
+    expect(state[childTree]).toBeUndefined();
+  });
+
   it("sets rootId on the first runtime binary tree node add", () => {
     let state = reduce(
       undefined,

--- a/src/entities/dataStructures/node/model/nodeSlice.ts
+++ b/src/entities/dataStructures/node/model/nodeSlice.ts
@@ -104,9 +104,11 @@ const collectSubtreeNodeIds = (
   const orderedIds: string[] = [];
   const visited = new Set<string>();
   const queue: string[] = [rootId];
+  let headIndex = 0;
 
-  while (queue.length > 0) {
-    const nodeId = queue.shift();
+  while (headIndex < queue.length) {
+    const nodeId = queue[headIndex];
+    headIndex += 1;
     if (!nodeId || visited.has(nodeId)) continue;
     visited.add(nodeId);
     orderedIds.push(nodeId);
@@ -287,7 +289,9 @@ export const treeNodeSlice = createSlice({
             .map((nodeId) => childTreeState.nodes.entities[nodeId])
             .filter((node): node is TreeNodeData => Boolean(node));
 
-          movedInternalEdges = Object.values(childTreeState.edges.entities).filter(
+          movedInternalEdges = Object.values(
+            childTreeState.edges.entities,
+          ).filter(
             (edge): edge is EdgeData =>
               Boolean(edge) &&
               subtreeIdSet.has(edge.sourceId) &&

--- a/src/entities/dataStructures/node/model/nodeSlice.ts
+++ b/src/entities/dataStructures/node/model/nodeSlice.ts
@@ -285,30 +285,30 @@ export const treeNodeSlice = createSlice({
           );
           const subtreeIdSet = new Set(subtreeIds);
 
-          movedNodes = subtreeIds
-            .map((nodeId) => childTreeState.nodes.entities[nodeId])
-            .filter((node): node is TreeNodeData => Boolean(node));
+          movedNodes = [];
+          for (const nodeId of subtreeIds) {
+            const node = childTreeState.nodes.entities[nodeId];
+            if (node) {
+              movedNodes.push(node);
+            }
+          }
 
-          movedInternalEdges = Object.values(
-            childTreeState.edges.entities,
-          ).filter(
-            (edge): edge is EdgeData =>
-              Boolean(edge) &&
-              subtreeIdSet.has(edge.sourceId) &&
-              subtreeIdSet.has(edge.targetId),
-          );
+          movedInternalEdges = [];
+          const edgeIdsTouchingSubtree: string[] = [];
+          for (const edge of Object.values(childTreeState.edges.entities)) {
+            if (!edge) continue;
+            const sourceInSubtree = subtreeIdSet.has(edge.sourceId);
+            const targetInSubtree = subtreeIdSet.has(edge.targetId);
+            if (sourceInSubtree && targetInSubtree) {
+              movedInternalEdges.push(edge);
+            }
+            if (sourceInSubtree || targetInSubtree) {
+              edgeIdsTouchingSubtree.push(edge.id);
+            }
+          }
 
-          const edgesTouchingSubtree = Object.values(
-            childTreeState.edges.entities,
-          ).filter(
-            (edge): edge is EdgeData =>
-              Boolean(edge) &&
-              (subtreeIdSet.has(edge.sourceId) ||
-                subtreeIdSet.has(edge.targetId)),
-          );
-
-          for (const edge of edgesTouchingSubtree) {
-            edgeDataAdapter.removeOne(childTreeState.edges, edge.id);
+          for (const edgeId of edgeIdsTouchingSubtree) {
+            edgeDataAdapter.removeOne(childTreeState.edges, edgeId);
           }
 
           treeNodeDataAdapter.removeMany(childTreeState.nodes, subtreeIds);

--- a/src/entities/dataStructures/node/model/nodeSlice.ts
+++ b/src/entities/dataStructures/node/model/nodeSlice.ts
@@ -155,6 +155,9 @@ const deleteTreeNode = (
   if (count === 1 && cleanupState) {
     delete state[treeName];
   } else {
+    if (treeState.rootId === id) {
+      treeState.rootId = null;
+    }
     treeNodeDataAdapter.removeOne(treeState.nodes, id);
   }
 };
@@ -192,6 +195,11 @@ export const treeNodeSlice = createSlice({
       const nodeId = action.payload.data.id;
       treeState.nodes.ids.push(nodeId);
       treeState.nodes.entities[nodeId] = action.payload.data;
+
+      // Runtime binary trees share one Redux tree per logical structure; first added node is the root for layout.
+      if (argType === ArgumentType.BINARY_TREE && treeState.rootId === null) {
+        treeState.rootId = nodeId;
+      }
 
       state[name] = treeState;
     },

--- a/src/entities/dataStructures/node/model/nodeSlice.ts
+++ b/src/entities/dataStructures/node/model/nodeSlice.ts
@@ -96,6 +96,33 @@ const restoreInitialEdges = (treeState: TreeData) => {
   );
 };
 
+/** All node ids in the subtree rooted at `rootId` (BFS over `childrenIds`). */
+const collectSubtreeNodeIds = (
+  entities: TreeData["nodes"]["entities"],
+  rootId: string,
+): string[] => {
+  const orderedIds: string[] = [];
+  const visited = new Set<string>();
+  const queue: string[] = [rootId];
+
+  while (queue.length > 0) {
+    const nodeId = queue.shift();
+    if (!nodeId || visited.has(nodeId)) continue;
+    visited.add(nodeId);
+    orderedIds.push(nodeId);
+
+    const node = entities[nodeId];
+    if (!node) continue;
+    for (const childId of node.childrenIds) {
+      if (childId) {
+        queue.push(childId);
+      }
+    }
+  }
+
+  return orderedIds;
+};
+
 const applyChildIdUpdates = (
   treeState: TreeData,
   id: string,
@@ -240,21 +267,65 @@ export const treeNodeSlice = createSlice({
     ) => {
       const { childId, childTreeName } = action.payload.data;
 
-      // If child is from another tree, remove it from the old tree and add it to the new one
+      // If child is from another tree, move the whole subtree (not only the root node) so
+      // descendants stay linked when a parent node is re-parented under a new BinaryTree name.
       if (childId && childTreeName && childTreeName !== action.payload.name) {
-        let childData: TreeNodeData | undefined = undefined;
+        let movedNodes: TreeNodeData[] = [];
+        let movedInternalEdges: EdgeData[] = [];
+
         runStateActionByName(state, childTreeName, (childTreeState) => {
-          childData = childTreeState.nodes.entities[childId];
+          const childData = childTreeState.nodes.entities[childId];
           if (!childData) return;
 
-          deleteTreeNode(state, childTreeName, childTreeState, childId, false);
+          const subtreeIds = collectSubtreeNodeIds(
+            childTreeState.nodes.entities,
+            childId,
+          );
+          const subtreeIdSet = new Set(subtreeIds);
+
+          movedNodes = subtreeIds
+            .map((nodeId) => childTreeState.nodes.entities[nodeId])
+            .filter((node): node is TreeNodeData => Boolean(node));
+
+          movedInternalEdges = Object.values(childTreeState.edges.entities).filter(
+            (edge): edge is EdgeData =>
+              Boolean(edge) &&
+              subtreeIdSet.has(edge.sourceId) &&
+              subtreeIdSet.has(edge.targetId),
+          );
+
+          const edgesTouchingSubtree = Object.values(
+            childTreeState.edges.entities,
+          ).filter(
+            (edge): edge is EdgeData =>
+              Boolean(edge) &&
+              (subtreeIdSet.has(edge.sourceId) ||
+                subtreeIdSet.has(edge.targetId)),
+          );
+
+          for (const edge of edgesTouchingSubtree) {
+            edgeDataAdapter.removeOne(childTreeState.edges, edge.id);
+          }
+
+          treeNodeDataAdapter.removeMany(childTreeState.nodes, subtreeIds);
+
+          if (childTreeState.nodes.ids.length === 0) {
+            delete state[childTreeName];
+          } else if (
+            childTreeState.rootId &&
+            subtreeIdSet.has(childTreeState.rootId)
+          ) {
+            childTreeState.rootId = null;
+          }
         });
 
         runStateActionByName(state, action.payload.name, (treeState) => {
-          if (!childData) return;
+          if (movedNodes.length === 0) return;
 
-          childData.childrenIds = []; // TODO: Allow to keep track of relations to different trees
-          treeNodeDataAdapter.addOne(treeState.nodes, childData);
+          treeNodeDataAdapter.addMany(treeState.nodes, movedNodes);
+          if (movedInternalEdges.length > 0) {
+            edgeDataAdapter.addMany(treeState.edges, movedInternalEdges);
+          }
         });
       }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When user code built a binary tree with `new BinaryTree(...)` and `root.left` / `root.right`, nodes appeared stacked at the same position (overlapping) instead of a proper tree with edges.

## Root cause

1. Each `BinaryTree` instance used a **new** `treeName` for Redux/callstack dispatch, while parent `setLeftChild` / `setRightChild` used the **parent’s** `treeName`. Child nodes were added under different tree keys than the edges, so the graph never connected.

2. `rootId` stayed **null** for runtime-built trees, so `useBinaryTreePositioning` bailed out and never spread nodes.

3. `new BinaryTree(val, left, right)` passed children through `super` without invoking setters, so subtrees would not merge under the parent in Redux.

4. Cross-tree `setChildId` only moved the **single** child node and cleared `childrenIds`, leaving descendants in the old Redux bucket. **Fix:** BFS-collect the subtree, move all nodes + internal edges, strip edges touching the subtree, delete empty source tree state.

## Changes

- **binaryTreeNode.ts**: One `treeName` per root `BinaryTree`; `adoptVisualizationTreeName` on `left`/`right` assignment. Runtime constructor assigns optional children via setters after `super`.

- **nodeSlice.ts**: Set `rootId` on first runtime `BINARY_TREE` add; clear when root removed. Cross-tree `setChildId`: move full subtree + internal edges (BFS queue uses index cursor for O(n)).

- **Tests**: `nodeSlice` — first add sets `rootId`, subtree move across trees, root removal clears `rootId`, partial move leaves unrelated nodes. `binaryTreeNode` — callstack `treeName` for children matches root after link and after 3-arg constructor.

No change required to user solutions such as the preorder/inorder `buildTree` snippet.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c8421a2-4725-4a96-b384-fdf4d023434a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c8421a2-4725-4a96-b384-fdf4d023434a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

