### PR TITLE
Fix binary tree callstack step-back: subtree revert and setRightChild parity

### DIFF
--- a/src/entities/dataStructures/node/model/__tests__/nodeSlice.test.ts
+++ b/src/entities/dataStructures/node/model/__tests__/nodeSlice.test.ts
@@ -180,6 +180,131 @@ describe("treeNodeSlice", () => {
     expect(state[childTree]).toBeUndefined();
   });
 
+  it("revertChildId moves the full subtree back to the original tree bucket", () => {
+    const parentTree = "parentTree";
+    const childTree = "childTree";
+
+    let state = reduce(
+      undefined,
+      treeNodeSlice.actions.init({
+        name: parentTree,
+        type: ArgumentType.BINARY_TREE,
+        order: 0,
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.init({
+        name: childTree,
+        type: ArgumentType.BINARY_TREE,
+        order: 1,
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.addMany({
+        name: parentTree,
+        data: {
+          maxDepth: 0,
+          nodes: [createNode("root", 3)],
+        },
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.addMany({
+        name: childTree,
+        data: {
+          maxDepth: 0,
+          nodes: [
+            createNode("subroot", 20, ["left", "right"]),
+            createNode("left", 15),
+            createNode("right", 7),
+          ],
+        },
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.addManyEdges({
+        name: childTree,
+        data: [
+          {
+            id: getEdgeId("subroot", "left"),
+            sourceId: "subroot",
+            targetId: "left",
+            isDirected: false,
+          },
+          {
+            id: getEdgeId("subroot", "right"),
+            sourceId: "subroot",
+            targetId: "right",
+            isDirected: false,
+          },
+        ],
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.setChildId({
+        name: parentTree,
+        data: {
+          id: "root",
+          index: 1,
+          childId: "subroot",
+          childTreeName: childTree,
+        },
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.revertChildId({
+        name: parentTree,
+        data: {
+          id: "root",
+          childId: "subroot",
+          childTreeName: childTree,
+        },
+      }),
+    );
+
+    state = reduce(
+      state,
+      treeNodeSlice.actions.setChildId({
+        name: parentTree,
+        data: {
+          id: "root",
+          index: 1,
+          childId: undefined,
+        },
+      }),
+    );
+
+    const parent = state[parentTree];
+    const restored = state[childTree];
+    expect(parent?.nodes.ids).toEqual(["root"]);
+    expect(parent?.edges.ids).toHaveLength(0);
+    expect(restored?.nodes.ids).toHaveLength(3);
+    expect(restored?.nodes.entities["subroot"]?.childrenIds).toEqual([
+      "left",
+      "right",
+    ]);
+    expect(restored?.edges.ids).toEqual(
+      expect.arrayContaining([
+        getEdgeId("subroot", "left"),
+        getEdgeId("subroot", "right"),
+      ]),
+    );
+    expect(restored?.edges.ids).toHaveLength(2);
+    expect(restored?.rootId).toBe("subroot");
+  });
+
   it("sets rootId on the first runtime binary tree node add", () => {
     let state = reduce(
       undefined,

--- a/src/entities/dataStructures/node/model/nodeSlice.ts
+++ b/src/entities/dataStructures/node/model/nodeSlice.ts
@@ -2,6 +2,7 @@ import {
   createEntityAdapter,
   createSelector,
   createSlice,
+  current,
   type EntityState,
   type PayloadAction,
 } from "@reduxjs/toolkit";
@@ -123,6 +124,105 @@ const collectSubtreeNodeIds = (
   }
 
   return orderedIds;
+};
+
+/** Move every node and internal edge in the subtree rooted at `subtreeRootId` from one tree bucket to another (playback undo uses the same path as forward cross-tree `setChildId`). */
+const moveSubtreeBetweenTreeBuckets = (
+  state: TreeDataState,
+  fromTreeName: string,
+  toTreeName: string,
+  subtreeRootId: string,
+) => {
+  if (fromTreeName === toTreeName) return;
+
+  const fromTreeState = getStateByName(state, fromTreeName);
+  if (!fromTreeState?.nodes.entities[subtreeRootId]) return;
+
+  const subtreeIds = collectSubtreeNodeIds(
+    fromTreeState.nodes.entities,
+    subtreeRootId,
+  );
+  const subtreeIdSet = new Set(subtreeIds);
+
+  const movedNodes: TreeNodeData[] = [];
+  for (const nodeId of subtreeIds) {
+    const node = fromTreeState.nodes.entities[nodeId];
+    if (node) {
+      const plain = current(node);
+      movedNodes.push({
+        ...plain,
+        childrenIds: [...plain.childrenIds],
+        info: plain.info ? { ...plain.info } : undefined,
+      });
+    }
+  }
+
+  const movedInternalEdges: EdgeData[] = [];
+  const edgeIdsTouchingSubtree: string[] = [];
+  for (const edge of Object.values(fromTreeState.edges.entities)) {
+    if (!edge) continue;
+    const sourceInSubtree = subtreeIdSet.has(edge.sourceId);
+    const targetInSubtree = subtreeIdSet.has(edge.targetId);
+    if (sourceInSubtree && targetInSubtree) {
+      movedInternalEdges.push({ ...current(edge) });
+    }
+    if (sourceInSubtree || targetInSubtree) {
+      edgeIdsTouchingSubtree.push(edge.id);
+    }
+  }
+
+  if (movedNodes.length === 0) return;
+
+  if (!getStateByName(state, toTreeName)) {
+    const sampleArgType = movedNodes[0]?.argType;
+    if (sampleArgType) {
+      state[toTreeName] = {
+        ...getInitialData(sampleArgType, 999),
+        isRuntime: true,
+      };
+    }
+  }
+
+  // Insert into destination before removing from source so Immer never sees dangling draft-only data.
+  runStateActionByName(state, toTreeName, (toTreeState) => {
+    const hadNoNodesBeforeMove = toTreeState.nodes.ids.length === 0;
+
+    // Manual insert: entity adapter `addMany` skipped inserts when moving snapshots from another
+    // tree under the same Immer produce (duplicate id bookkeeping). Direct assignment is reliable.
+    for (const node of movedNodes) {
+      if (!(node.id in toTreeState.nodes.entities)) {
+        toTreeState.nodes.ids.push(node.id);
+      }
+      toTreeState.nodes.entities[node.id] = node;
+    }
+    for (const edge of movedInternalEdges) {
+      if (!(edge.id in toTreeState.edges.entities)) {
+        toTreeState.edges.ids.push(edge.id);
+      }
+      toTreeState.edges.entities[edge.id] = edge;
+    }
+
+    if (
+      hadNoNodesBeforeMove &&
+      toTreeState.type === ArgumentType.BINARY_TREE &&
+      toTreeState.rootId === null
+    ) {
+      toTreeState.rootId = subtreeRootId;
+    }
+  });
+
+  runStateActionByName(state, fromTreeName, (mutableFrom) => {
+    for (const edgeId of edgeIdsTouchingSubtree) {
+      edgeDataAdapter.removeOne(mutableFrom.edges, edgeId);
+    }
+    treeNodeDataAdapter.removeMany(mutableFrom.nodes, subtreeIds);
+
+    if (mutableFrom.nodes.ids.length === 0) {
+      delete state[fromTreeName];
+    } else if (mutableFrom.rootId && subtreeIdSet.has(mutableFrom.rootId)) {
+      mutableFrom.rootId = null;
+    }
+  });
 };
 
 const applyChildIdUpdates = (
@@ -272,65 +372,12 @@ export const treeNodeSlice = createSlice({
       // If child is from another tree, move the whole subtree (not only the root node) so
       // descendants stay linked when a parent node is re-parented under a new BinaryTree name.
       if (childId && childTreeName && childTreeName !== action.payload.name) {
-        let movedNodes: TreeNodeData[] = [];
-        let movedInternalEdges: EdgeData[] = [];
-
-        runStateActionByName(state, childTreeName, (childTreeState) => {
-          const childData = childTreeState.nodes.entities[childId];
-          if (!childData) return;
-
-          const subtreeIds = collectSubtreeNodeIds(
-            childTreeState.nodes.entities,
-            childId,
-          );
-          const subtreeIdSet = new Set(subtreeIds);
-
-          movedNodes = [];
-          for (const nodeId of subtreeIds) {
-            const node = childTreeState.nodes.entities[nodeId];
-            if (node) {
-              movedNodes.push(node);
-            }
-          }
-
-          movedInternalEdges = [];
-          const edgeIdsTouchingSubtree: string[] = [];
-          for (const edge of Object.values(childTreeState.edges.entities)) {
-            if (!edge) continue;
-            const sourceInSubtree = subtreeIdSet.has(edge.sourceId);
-            const targetInSubtree = subtreeIdSet.has(edge.targetId);
-            if (sourceInSubtree && targetInSubtree) {
-              movedInternalEdges.push(edge);
-            }
-            if (sourceInSubtree || targetInSubtree) {
-              edgeIdsTouchingSubtree.push(edge.id);
-            }
-          }
-
-          for (const edgeId of edgeIdsTouchingSubtree) {
-            edgeDataAdapter.removeOne(childTreeState.edges, edgeId);
-          }
-
-          treeNodeDataAdapter.removeMany(childTreeState.nodes, subtreeIds);
-
-          if (childTreeState.nodes.ids.length === 0) {
-            delete state[childTreeName];
-          } else if (
-            childTreeState.rootId &&
-            subtreeIdSet.has(childTreeState.rootId)
-          ) {
-            childTreeState.rootId = null;
-          }
-        });
-
-        runStateActionByName(state, action.payload.name, (treeState) => {
-          if (movedNodes.length === 0) return;
-
-          treeNodeDataAdapter.addMany(treeState.nodes, movedNodes);
-          if (movedInternalEdges.length > 0) {
-            edgeDataAdapter.addMany(treeState.edges, movedInternalEdges);
-          }
-        });
+        moveSubtreeBetweenTreeBuckets(
+          state,
+          childTreeName,
+          action.payload.name,
+          childId,
+        );
       }
 
       // Normal child id update
@@ -367,21 +414,21 @@ export const treeNodeSlice = createSlice({
         childTreeName?: string;
       }>,
     ) => {
-      const { id, childId, childTreeName } = action.payload.data;
+      const { childId, childTreeName } = action.payload.data;
       if (!childId || !childTreeName || action.payload.name === childTreeName)
         return;
 
-      runStateActionByName(state, action.payload.name, (treeState) => {
-        const node = treeNodeDataSelector.selectById(treeState.nodes, id);
-        const childData = treeState.nodes.entities[childId];
-        if (!node || !childData) return;
+      const parentTreeName = action.payload.name;
+      const parentTree = getStateByName(state, parentTreeName);
+      const childNode = parentTree?.nodes.entities[childId];
+      if (!childNode) return;
 
-        deleteTreeNode(state, action.payload.name, treeState, childData.id);
-
-        runStateActionByName(state, childTreeName, (childTreeState) => {
-          treeNodeDataAdapter.addOne(childTreeState.nodes, childData);
-        });
-      });
+      moveSubtreeBetweenTreeBuckets(
+        state,
+        parentTreeName,
+        childTreeName,
+        childId,
+      );
     },
     dragNode: (
       state,

--- a/src/features/treeViewer/hooks/__tests__/useNodesRuntimeUpdates.test.tsx
+++ b/src/features/treeViewer/hooks/__tests__/useNodesRuntimeUpdates.test.tsx
@@ -5,6 +5,10 @@ import { Provider } from "react-redux";
 import { describe, expect, it, vi } from "vitest";
 
 import { ArgumentType } from "#/entities/argument/model/argumentObject";
+import {
+  getEdgeId,
+  treeNodeSlice,
+} from "#/entities/dataStructures/node/model/nodeSlice";
 import type {
   CallFrame,
   CallstackState,
@@ -30,10 +34,14 @@ const createMockFrame = (
   args: { value },
 });
 
-const createStoreWithCallstack = (callstack: Partial<CallstackState>) =>
+const createStoreWithCallstack = (
+  callstack: Partial<CallstackState>,
+  extraPreloaded?: Partial<RootState>,
+) =>
   configureStore({
     reducer: rootReducer,
     preloadedState: {
+      ...extraPreloaded,
       callstack: {
         isReady: true,
         isPlaying: false,
@@ -44,10 +52,114 @@ const createStoreWithCallstack = (callstack: Partial<CallstackState>) =>
         frames: { ids: [], entities: {} },
         frameIndex: -1,
         resetVersion: 0,
+        lastRunCodeSource: null,
+        codeModifiedSinceRun: false,
         ...callstack,
       },
     } as Partial<RootState>,
   });
+
+const seedCrossTreeForPlayback = (parentTree: string, childTree: string) => {
+  type TreeAction = ReturnType<
+    (typeof treeNodeSlice.actions)[keyof typeof treeNodeSlice.actions]
+  >;
+  let treeState: RootState["treeNode"] | undefined;
+  const reduce = (action: TreeAction) => {
+    treeState = treeNodeSlice.reducer(treeState, action);
+  };
+
+  reduce(
+    treeNodeSlice.actions.init({
+      name: parentTree,
+      type: ArgumentType.BINARY_TREE,
+      order: 0,
+    }),
+  );
+  reduce(
+    treeNodeSlice.actions.init({
+      name: childTree,
+      type: ArgumentType.BINARY_TREE,
+      order: 1,
+    }),
+  );
+  reduce(
+    treeNodeSlice.actions.addMany({
+      name: parentTree,
+      data: {
+        maxDepth: 0,
+        nodes: [
+          {
+            id: "root",
+            value: 3,
+            argType: ArgumentType.BINARY_TREE,
+            depth: 0,
+            x: 0,
+            y: 0,
+            childrenIds: [],
+          },
+        ],
+      },
+    }),
+  );
+  reduce(
+    treeNodeSlice.actions.addMany({
+      name: childTree,
+      data: {
+        maxDepth: 0,
+        nodes: [
+          {
+            id: "subroot",
+            value: 20,
+            argType: ArgumentType.BINARY_TREE,
+            depth: 0,
+            x: 0,
+            y: 0,
+            childrenIds: ["leafL", "leafR"],
+          },
+          {
+            id: "leafL",
+            value: 15,
+            argType: ArgumentType.BINARY_TREE,
+            depth: 0,
+            x: 0,
+            y: 0,
+            childrenIds: [],
+          },
+          {
+            id: "leafR",
+            value: 7,
+            argType: ArgumentType.BINARY_TREE,
+            depth: 0,
+            x: 0,
+            y: 0,
+            childrenIds: [],
+          },
+        ],
+      },
+    }),
+  );
+  reduce(
+    treeNodeSlice.actions.addManyEdges({
+      name: childTree,
+      data: [
+        {
+          id: getEdgeId("subroot", "leafL"),
+          sourceId: "subroot",
+          targetId: "leafL",
+          isDirected: false,
+        },
+        {
+          id: getEdgeId("subroot", "leafR"),
+          sourceId: "subroot",
+          targetId: "leafR",
+          isDirected: false,
+        },
+      ],
+    }),
+  );
+
+  return treeState ?? {};
+};
 
 const createWrapper =
   (store: ReturnType<typeof createStoreWithCallstack>) =>
@@ -56,6 +168,58 @@ const createWrapper =
   );
 
 describe("useNodesRuntimeUpdates", () => {
+  it("reverting setRightChild after cross-tree attach restores subtree to the child bucket", () => {
+    const parentTree = "parentRuntime";
+    const childTree = "childRuntime";
+
+    const store = createStoreWithCallstack(
+      {
+        frames: {
+          ids: ["attachRight"],
+          entities: {
+            attachRight: {
+              id: "attachRight",
+              timestamp: 1,
+              name: "setRightChild",
+              treeName: parentTree,
+              nodeId: "root",
+              structureType: "treeNode",
+              argType: ArgumentType.BINARY_TREE,
+              args: {
+                childId: "subroot",
+                childTreeName: childTree,
+              },
+              prevArgs: { childId: null, childTreeName: undefined },
+            } satisfies CallFrame,
+          },
+        },
+        frameIndex: -1,
+      },
+      { treeNode: seedCrossTreeForPlayback(parentTree, childTree) },
+    );
+
+    renderHook(() => useNodesRuntimeUpdates(20), {
+      wrapper: createWrapper(store),
+    });
+
+    act(() => {
+      store.dispatch(callstackSlice.actions.setFrameIndex(0));
+    });
+
+    const afterAttach = store.getState().treeNode[parentTree];
+    expect(afterAttach?.nodes.ids).toHaveLength(4);
+
+    act(() => {
+      store.dispatch(callstackSlice.actions.setFrameIndex(-1));
+    });
+
+    const parent = store.getState().treeNode[parentTree];
+    const restored = store.getState().treeNode[childTree];
+    expect(parent?.nodes.ids).toEqual(["root"]);
+    expect(restored?.nodes.ids).toHaveLength(3);
+    expect(restored?.edges.ids).toHaveLength(2);
+  });
+
   it("continues autoplay after replay resets the frame index", () => {
     vi.useFakeTimers();
 

--- a/src/features/treeViewer/hooks/useNodesRuntimeUpdates.ts
+++ b/src/features/treeViewer/hooks/useNodesRuntimeUpdates.ts
@@ -335,6 +335,17 @@ export const useNodesRuntimeUpdates = (playbackInterval: number) => {
 
         case "setRightChild":
           if (frame.prevArgs) {
+            if ("revertChildId" in slice.actions) {
+              dispatch(
+                slice.actions.revertChildId({
+                  name: treeName,
+                  data: {
+                    id: frame.nodeId,
+                    ...frame.args,
+                  },
+                }),
+              );
+            }
             applyFrame({
               ...frame,
               name: "setRightChild",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Follow-up to #127 (runtime `BinaryTree` layout). After merging the layout fix, stepping the callstack **backward** could leave **orphan nodes and edges** (e.g. partial tree at frame `-1`) because undo did not mirror the forward cross-tree subtree move.

## What changed

- **`treeNodeSlice.revertChildId`**: Moves the **entire subtree** back to `childTreeName` using the same rules as forward cross-tree `setChildId` (BFS node ids, internal edges, strip edges touching the subtree). Recreates an empty runtime tree bucket when the source tree was deleted; restores **`rootId`** when repopulating an empty binary tree.

- **`moveSubtreeBetweenTreeBuckets`**: Shared helper for forward + revert; **insert into destination before removing from source**; **direct `ids` / `entities` writes** for the destination insert (RTK `addMany` could skip inserts when moving snapshots under the same Immer `produce`).

- **`useNodesRuntimeUpdates`**: **`setRightChild` revert** now dispatches **`revertChildId`** before re-applying `prevArgs`, matching **`setLeftChild`**.

- **Tests**: `nodeSlice` revert + detach; hook test stepping `setRightChild` then `frameIndex` back to `-1`.

## Verification

`pnpm test:ci` passes (Vitest + Python harness).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5c8421a2-4725-4a96-b384-fdf4d023434a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5c8421a2-4725-4a96-b384-fdf4d023434a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

