### PR TITLE
fix(cloud): ensure DATABASE_URL before pnpm install on Cloud agents

### DIFF
--- a/.cursor/cloud-agent-update.sh
+++ b/.cursor/cloud-agent-update.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Idempotent Cursor Cloud "install" / update script (see .cursor/environment.json).
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "Starting PostgreSQL 16 database server"
+if command -v service >/dev/null 2>&1; then
+  sudo service postgresql start
+else
+  echo "WARNING: service command not found; ensure PostgreSQL is running" >&2
+fi
+
+if [ -s "${NVM_DIR:-$HOME/.nvm}/nvm.sh" ]; then
+  # shellcheck source=/dev/null
+  . "${NVM_DIR:-$HOME/.nvm}/nvm.sh"
+fi
+
+if [ -f .nvmrc ]; then
+  nvm use
+fi
+
+ENV_TEMPLATE="${REPO_ROOT}/.cursor/cloud-agent.env.template"
+if [ ! -f .env ]; then
+  if [ ! -f "$ENV_TEMPLATE" ]; then
+    echo "ERROR: missing .env and ${ENV_TEMPLATE}" >&2
+    exit 1
+  fi
+  cp "$ENV_TEMPLATE" .env
+  echo "Created .env from .cursor/cloud-agent.env.template"
+fi
+
+# load-env merges .env then .env.local; export defaults so postinstall works even if .env lacks keys
+set -a
+# shellcheck source=/dev/null
+[ -f .env ] && . ./.env
+[ -f .env.local ] && . ./.env.local
+set +a
+
+export DATABASE_URL="${DATABASE_URL:-postgresql://dstruct:dstruct@localhost:5432/dstruct}"
+export PRISMA_FIELD_ENCRYPTION_KEY="${PRISMA_FIELD_ENCRYPTION_KEY:-dev-local-encryption-key-for-testing-only}"
+export SKIP_ENV_VALIDATION="${SKIP_ENV_VALIDATION:-true}"
+
+if command -v corepack >/dev/null 2>&1; then
+  corepack enable
+fi
+
+pnpm install
+
+# Schema push is safe to repeat; keeps fresh VMs aligned with prisma/schema.prisma
+pnpm prisma:push
+
+echo "Cloud agent update finished successfully"

--- a/.cursor/cloud-agent.env.template
+++ b/.cursor/cloud-agent.env.template
@@ -1,0 +1,21 @@
+# Local development defaults for Cursor Cloud agents.
+# Copied to `.env` when missing during `.cursor/cloud-agent-update.sh`.
+# Override via Cursor Secrets or `.env.local` (gitignored).
+
+DATABASE_URL=postgresql://dstruct:dstruct@localhost:5432/dstruct
+PRISMA_FIELD_ENCRYPTION_KEY=dev-local-encryption-key-for-testing-only
+SKIP_ENV_VALIDATION=true
+NODE_ENV=development
+
+NEXTAUTH_SECRET=dev-nextauth-secret-replace-in-production
+NEXTAUTH_URL=http://localhost:3000
+
+GITHUB_CLIENT_ID=dev-github-client-id
+GITHUB_CLIENT_SECRET=dev-github-client-secret
+GOOGLE_CLIENT_ID=dev-google-client-id
+GOOGLE_CLIENT_SECRET=dev-google-client-secret
+
+ACCESS_KEY=dev-aws-access-key
+SECRET_KEY=dev-aws-secret-key
+BUCKET_NAME=dev-bucket
+NEXT_PUBLIC_BUCKET_BASE_URL=https://example.com

--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,11 @@
+{
+  "install": "bash .cursor/cloud-agent-update.sh",
+  "start": "sudo service postgresql start",
+  "terminals": [
+    {
+      "name": "Next.js dev server",
+      "command": "pnpm dev",
+      "description": "Runs the app on http://localhost:3000"
+    }
+  ]
+}

--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,11 @@
 
 # When adding additional env variables, the schema in /env/schema.mjs should be updated accordingly
 
-# Prisma
-DATABASE_URL=file:./db.sqlite
+# Prisma (PostgreSQL — see AGENTS.md for local / Cursor Cloud defaults)
+DATABASE_URL=postgresql://dstruct:dstruct@localhost:5432/dstruct
+PRISMA_FIELD_ENCRYPTION_KEY=dev-local-encryption-key-for-testing-only
+SKIP_ENV_VALIDATION=true
+NODE_ENV=development
 
 # Next Auth
 # You can generate the secret via 'openssl rand -base64 32' on Linux
@@ -19,5 +22,12 @@ NEXTAUTH_URL=http://localhost:3000
 #DISCORD_CLIENT_ID=
 #DISCORD_CLIENT_SECRET=
 
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
+GITHUB_CLIENT_ID=dev-github-client-id
+GITHUB_CLIENT_SECRET=dev-github-client-secret
+GOOGLE_CLIENT_ID=dev-google-client-id
+GOOGLE_CLIENT_SECRET=dev-google-client-secret
+
+ACCESS_KEY=dev-aws-access-key
+SECRET_KEY=dev-aws-secret-key
+BUCKET_NAME=dev-bucket
+NEXT_PUBLIC_BUCKET_BASE_URL=https://example.com

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,16 @@ Cursor rules to apply (see each file for full wording):
 
 ## Cursor Cloud specific instructions
 
+### Cloud agent update (`install`)
+
+Repo-level config is in **`.cursor/environment.json`**. The **`install`** command runs **`bash .cursor/cloud-agent-update.sh`**, which:
+
+1. Starts PostgreSQL
+2. Creates **`.env`** from **`.cursor/cloud-agent.env.template`** when missing (so **`pnpm install`** / postinstall Prisma generate succeed)
+3. Runs **`pnpm install`** and **`pnpm prisma:push`**
+
+If you override the dashboard update script, keep step 2 before **`pnpm install`**, or rely on **`prisma.config.ts`** local URL fallback and Cursor Secrets for **`DATABASE_URL`**.
+
 ### Services overview
 
 | Service            | Command                         | Notes                                                                        |

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,6 +1,9 @@
 import "dotenv/config";
 import type { PrismaConfig } from "prisma";
-import { env } from "prisma/config";
+
+/** Matches AGENTS.md / Cursor Cloud local PostgreSQL defaults; used only when env is unset (e.g. postinstall). */
+const DEFAULT_LOCAL_DATABASE_URL =
+  "postgresql://dstruct:dstruct@localhost:5432/dstruct";
 
 export default {
   schema: "prisma/schema.prisma",
@@ -10,6 +13,9 @@ export default {
   },
   datasource: {
     // Prefer direct URL for CLI (migrate, studio) when using a connection pooler; app uses DATABASE_URL at runtime
-    url: process.env.DIRECT_DATABASE_URL ?? env("DATABASE_URL"),
+    url:
+      process.env.DIRECT_DATABASE_URL ??
+      process.env.DATABASE_URL ??
+      DEFAULT_LOCAL_DATABASE_URL,
   },
 } satisfies PrismaConfig;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Cloud agent `pnpm install` failed during postinstall because Prisma could not resolve `DATABASE_URL`:

```
PrismaConfigEnvError: Cannot resolve environment variable: DATABASE_URL
```

The update flow started PostgreSQL and ran `pnpm install` before a `.env` file existed.

## Solution

1. **`.cursor/environment.json`** — points `install` at `bash .cursor/cloud-agent-update.sh` and starts PostgreSQL on machine boot.
2. **`.cursor/cloud-agent-update.sh`** — idempotent update script: start Postgres → ensure `.env` from template → `pnpm install` → `pnpm prisma:push`.
3. **`.cursor/cloud-agent.env.template`** — committed local-dev defaults (PostgreSQL URL, `SKIP_ENV_VALIDATION`, placeholder OAuth/AWS keys).
4. **`prisma.config.ts`** — fallback to `postgresql://dstruct:dstruct@localhost:5432/dstruct` when env vars are unset so `prisma generate` succeeds during postinstall even without `.env`.
5. **`.env.example`** / **`AGENTS.md`** — aligned docs and example with PostgreSQL + install flow.

## Verification

Ran `bash .cursor/cloud-agent-update.sh` on a clean VM (no `.env`): postinstall, Prisma generate, GraphQL codegen, and `prisma db push` all succeeded.

## Dashboard note

If a saved Cloud environment still uses a custom update command (e.g. bare `pnpm install`), either switch to repo `.cursor/environment.json` or ensure `.env` exists before install.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ce360d2-fdb0-4bfe-b82c-993fce1b510a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ce360d2-fdb0-4bfe-b82c-993fce1b510a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

