### PR TITLE
fix(env): harden codegen recovery and align .env.example with Postgres

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,23 +1,31 @@
-# Since .env is gitignored, you can use .env.example to build a new `.env` file when you clone the repo.
+# Since .env is gitignored, copy this file to `.env` when you clone the repo.
 # Keep this file up-to-date when you add new variables to `.env`.
+#
+# Local dev (PostgreSQL): user `dstruct`, password `dstruct`, database `dstruct` on localhost:5432.
+# Cloud agent startup scripts provision this automatically; otherwise run `pnpm prisma:push`.
 
-# This file will be committed to version control, so make sure not to have any secrets in it.
-# If you are cloning this repo, create a copy of this file named `.env` and populate it with your secrets.
+# When adding additional env variables, update the schema in src/env/schema.mjs accordingly.
 
-# When adding additional env variables, the schema in /env/schema.mjs should be updated accordingly
+NODE_ENV=development
 
-# Prisma
-DATABASE_URL=file:./db.sqlite
+# Prisma (PostgreSQL). DIRECT_DATABASE_URL is optional; used by Prisma CLI when bypassing a pooler.
+DATABASE_URL=postgresql://dstruct:dstruct@localhost:5432/dstruct
+DIRECT_DATABASE_URL=postgresql://dstruct:dstruct@localhost:5432/dstruct
+PRISMA_FIELD_ENCRYPTION_KEY=dev-local-encryption-key-for-testing-only
 
-# Next Auth
-# You can generate the secret via 'openssl rand -base64 32' on Linux
-# More info: https://next-auth.js.org/configuration/options#secret
-# NEXTAUTH_SECRET=
+# Next Auth — generate a secret via `openssl rand -base64 32`
+# https://next-auth.js.org/configuration/options#secret
+NEXTAUTH_SECRET=dev-local-nextauth-secret
 NEXTAUTH_URL=http://localhost:3000
 
-# Next Auth Discord Provider
-#DISCORD_CLIENT_ID=
-#DISCORD_CLIENT_SECRET=
+# OAuth providers (placeholder values are fine for local dev)
+GITHUB_CLIENT_ID=placeholder
+GITHUB_CLIENT_SECRET=placeholder
+GOOGLE_CLIENT_ID=placeholder
+GOOGLE_CLIENT_SECRET=placeholder
 
-GITHUB_CLIENT_ID=
-GITHUB_CLIENT_SECRET=
+# S3 / object storage (placeholder values are fine for local dev)
+ACCESS_KEY=placeholder
+SECRET_KEY=placeholder
+BUCKET_NAME=placeholder
+NEXT_PUBLIC_BUCKET_BASE_URL=https://example.com

--- a/src/scripts/ensureGeneratedFromInstall.ts
+++ b/src/scripts/ensureGeneratedFromInstall.ts
@@ -7,7 +7,7 @@
  * Cheap no-op when the artifacts already exist; otherwise regenerates them.
  */
 import { execSync } from "node:child_process";
-import { existsSync } from "node:fs";
+import { existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 const repoRoot = process.cwd();
@@ -16,12 +16,20 @@ const ensureGenerated = (
   label: string,
   sentinelPath: string,
   command: string,
+  outputDir?: string,
 ): void => {
   if (existsSync(sentinelPath)) {
     console.log(
       `[ensure-generated-from-install] ${label} output present; skipping.`,
     );
     return;
+  }
+
+  if (outputDir && existsSync(outputDir)) {
+    console.warn(
+      `[ensure-generated-from-install] Removing stale ${label} output at ${outputDir}…`,
+    );
+    rmSync(outputDir, { recursive: true, force: true });
   }
 
   console.warn(
@@ -34,10 +42,12 @@ ensureGenerated(
   "GraphQL codegen",
   join(repoRoot, "src", "graphql", "generated", "index.tsx"),
   "pnpm run generate-graphql",
+  join(repoRoot, "src", "graphql", "generated"),
 );
 
 ensureGenerated(
   "Prisma client",
   join(repoRoot, "src", "server", "db", "generated", "client.ts"),
   "pnpm run prisma:generate",
+  join(repoRoot, "src", "server", "db", "generated"),
 );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Two small follow-ups from the env/startup verification:

1. **`ensureGeneratedFromInstall.ts`** — When the Prisma (or GraphQL) sentinel file is missing but a stale output directory still exists, `prisma generate` fails with "exists and is not empty but doesn't look like a generated Prisma Client". The script now removes the stale output directory before regenerating.

2. **`.env.example`** — Replaced the outdated SQLite `DATABASE_URL` with the PostgreSQL local-dev defaults and documented the other required env vars so new clones match what cloud startup scripts provision.

## Verification

- Deleted `client.ts` only, ran `pnpm run ensure-generated-from-install` → stale dir removed, Prisma client regenerated successfully.
- Pre-push: `pnpm lint` + `pnpm test` (319 tests) passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-333d3416-02fb-4c63-83dd-b7c1d7492212?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-333d3416-02fb-4c63-83dd-b7c1d7492212&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

