### PR TITLE
Fix cookie settings banner horizontal space on mobile

### DIFF
--- a/src/features/cookieConsent/ui/CookieConsentBanner.tsx
+++ b/src/features/cookieConsent/ui/CookieConsentBanner.tsx
@@ -96,10 +96,15 @@ export const CookieConsentBanner: React.FC<CookieConsentBannerProps> = ({
           sx={{
             alignItems: { xs: "stretch", sm: "center" },
             justifyContent: "space-between",
-            pr: isSettingsView ? 4 : 0,
           }}
         >
-          <Box sx={{ minWidth: 0 }}>
+          <Box
+            sx={{
+              minWidth: 0,
+              // Reserve space for the overlaid close control without narrowing buttons.
+              pr: isSettingsView ? 5 : 0,
+            }}
+          >
             <Typography
               id="cookie-consent-title"
               variant="subtitle2"

--- a/src/features/cookieConsent/ui/CookieConsentBanner.tsx
+++ b/src/features/cookieConsent/ui/CookieConsentBanner.tsx
@@ -25,7 +25,7 @@ type CookieConsentBannerProps = {
   onAcceptAll: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onRejectNonEssential: (event: React.MouseEvent<HTMLButtonElement>) => void;
   onClose: (event: React.MouseEvent<HTMLButtonElement>) => void;
-  /** Visual surface used by optional dismiss effects (e.g. Thanos disintegrate). */
+  /** Visual surface used by optional dismiss effects (e.g. DOM disintegrate). */
   surfaceRef?: React.Ref<HTMLDivElement>;
 };
 

--- a/src/features/cookieConsent/ui/CookieConsentBannerWithDismissEffect.tsx
+++ b/src/features/cookieConsent/ui/CookieConsentBannerWithDismissEffect.tsx
@@ -52,13 +52,16 @@ export const CookieConsentBannerWithDismissEffect: React.FC<
           return;
         }
 
+        const settingsViewAtDismiss = isSettingsView;
+        setFrozenSettingsView(settingsViewAtDismiss);
+
         const persisted = action();
         if (persisted === false) {
+          setFrozenSettingsView(null);
           return;
         }
 
         isDismissingRef.current = true;
-        setFrozenSettingsView(isSettingsView);
         onBeginDismiss();
 
         void (async () => {

--- a/src/features/cookieConsent/ui/__tests__/CookieConsentBannerWithDismissEffect.test.tsx
+++ b/src/features/cookieConsent/ui/__tests__/CookieConsentBannerWithDismissEffect.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { SnackbarProvider } from "notistack";
 import type * as Notistack from "notistack";
+import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
 import type * as SharedHooks from "#/shared/hooks";
@@ -125,6 +126,54 @@ describe("CookieConsentBannerWithDismissEffect", () => {
     expect(onBeginDismiss).not.toHaveBeenCalled();
     expect(disintegrateMock).not.toHaveBeenCalled();
     expect(onCompleteDismiss).not.toHaveBeenCalled();
+  });
+
+  it("keeps settings view frozen while close dismiss animation is pending", async () => {
+    disintegrateMock.mockClear();
+    const user = userEvent.setup();
+
+    const SettingsCloseHarness = () => {
+      const [isSettingsView, setIsSettingsView] = useState(true);
+
+      return (
+        <ThemeProvider theme={theme}>
+          <SnackbarProvider>
+            <CookieConsentBannerWithDismissEffect
+              isSettingsView={isSettingsView}
+              onAcceptAll={vi.fn(() => true)}
+              onRejectNonEssential={vi.fn()}
+              onClose={() => {
+                setIsSettingsView(false);
+              }}
+              onBeginDismiss={vi.fn()}
+              onCompleteDismiss={vi.fn()}
+            />
+          </SnackbarProvider>
+        </ThemeProvider>
+      );
+    };
+
+    render(<SettingsCloseHarness />);
+
+    await user.click(
+      screen.getByRole("button", { name: "COOKIE_SETTINGS_CLOSE" }),
+    );
+
+    expect(screen.getByText("COOKIE_SETTINGS_TITLE")).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "COOKIE_SETTINGS_CLOSE" }),
+    ).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(disintegrateMock).toHaveBeenCalledTimes(1);
+    });
+
+    resolveDisintegrate?.();
+    await waitFor(() => {
+      expect(
+        screen.queryByText("COOKIE_SETTINGS_TITLE"),
+      ).not.toBeInTheDocument();
+    });
   });
 
   it("still completes dismiss and shows a warning when the animation fails", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes wasted horizontal space in the cookie settings banner on mobile when the close (✕) button is absolutely positioned.

## Problem

In settings view, `padding-right` was applied to the outer `Stack`, which in column layout (mobile) inset the accept/reject buttons as if a dedicated close-button column existed — leaving empty space beside the actions.

## Fix

- Remove `pr` from the outer `Stack`
- Apply `pr: 5` only on the text `Box` so copy clears the overlaid close control without narrowing the action buttons

## Deep review follow-up

- **Race fix:** `CookieConsentBannerWithDismissEffect` now freezes `isSettingsView` **before** calling dismiss handlers (`onClose`, accept/reject). Previously, `onClose` could set `settingsOpen=false` synchronously so the banner flashed initial consent copy during the disintegrate animation.
- **Regression test:** settings view stays frozen while close-dismiss animation is pending.

## Test plan

- [x] `pnpm exec vitest run src/features/cookieConsent`
- [ ] Manual: open cookie settings on mobile → accept/reject buttons span full width; close ✕ does not create empty column
- [ ] Manual: close settings with disintegrate → settings copy/close button remain visible during animation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5443c79d-9217-4aaa-bfed-d047eb88543f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5443c79d-9217-4aaa-bfed-d047eb88543f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

