### PR TITLE
Fix category chip selected and hover styles in Project Browser

### DIFF
--- a/src/features/project/ui/ProjectBrowser/ProjectBrowserCategoryBar.tsx
+++ b/src/features/project/ui/ProjectBrowser/ProjectBrowserCategoryBar.tsx
@@ -1,6 +1,13 @@
 import ExpandLess from "@mui/icons-material/ExpandLess";
 import ExpandMore from "@mui/icons-material/ExpandMore";
-import { Box, Button, Chip, Typography } from "@mui/material";
+import {
+  alpha,
+  Box,
+  Button,
+  Chip,
+  Typography,
+  useTheme,
+} from "@mui/material";
 import React, { useMemo, useState } from "react";
 
 import { categoryLabels } from "#/entities/category/model/categoryLabels";
@@ -21,6 +28,7 @@ const COLLAPSED_MAX_HEIGHT = 64; // Single row + peek of second
 export const ProjectBrowserCategoryBar: React.FC<
   ProjectBrowserCategoryBarProps
 > = ({ projects }) => {
+  const theme = useTheme();
   const { selectedCategories, setSelectedCategories } =
     useProjectBrowserContext();
   const [isExpanded, setIsExpanded] = useState(false);
@@ -141,11 +149,26 @@ export const ProjectBrowserCategoryBar: React.FC<
                   label={`${label}: ${count}`}
                   onClick={() => handleCategoryClick(category)}
                   onKeyDown={(ev) => handleKeyDown(ev, category)}
-                  color={isSelected ? "primary" : "default"}
-                  variant={isSelected ? "filled" : "outlined"}
+                  variant="filled"
                   sx={{
                     cursor: "pointer",
                     fontWeight: isSelected ? 600 : 400,
+                    backgroundColor: isSelected
+                      ? theme.palette.info.main
+                      : alpha(theme.palette.info.main, 0.12),
+                    color: isSelected
+                      ? theme.palette.common.white
+                      : theme.palette.secondary.main,
+                    border: `1px solid ${
+                      isSelected
+                        ? theme.palette.info.main
+                        : alpha(theme.palette.secondary.main, 0.24)
+                    }`,
+                    "&:hover": {
+                      backgroundColor: isSelected
+                        ? alpha(theme.palette.info.main, 0.88)
+                        : alpha(theme.palette.info.main, 0.2),
+                    },
                     "&:focus-visible": {
                       outline: "2px solid",
                       outlineColor: "primary.main",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Category filter chips in the Project Browser had poor selected/hover styling:
- Selected chips were hard to distinguish from unselected chips when not hovering
- Hovering produced a light gray background with light blue text (very low contrast)

## Root cause

Global `MuiChip` theme overrides set accent-tinted background and soft blue text on all chips. Using MUI's `color="primary"` / `variant` props did not override those defaults cleanly, and the default Chip hover state applied `action.hover` (a gray overlay) on top of the accent text color.

## Fix

Category chips now use explicit `sx` styles instead of relying on `color`/`variant` props:
- **Unselected:** subtle accent-tinted background, soft blue text, light border
- **Selected:** solid accent blue (`info.main`) background with white text
- **Hover:** slightly stronger accent tint (unselected) or slightly dimmed blue (selected) — no gray overlay

## Testing
- `pnpm exec vitest run src/features/project/ui/ProjectBrowser/__tests__/` — all 85 tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-52eff041-b140-47b4-9473-8f020722917f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-52eff041-b140-47b4-9473-8f020722917f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

