### PR TITLE
fix: prevent category chip layout shift on selection

### DIFF
--- a/src/features/project/ui/ProjectBrowser/ProjectBrowserCategoryBar.tsx
+++ b/src/features/project/ui/ProjectBrowser/ProjectBrowserCategoryBar.tsx
@@ -1,13 +1,6 @@
 import ExpandLess from "@mui/icons-material/ExpandLess";
 import ExpandMore from "@mui/icons-material/ExpandMore";
-import {
-  alpha,
-  Box,
-  Button,
-  Chip,
-  Typography,
-  useTheme,
-} from "@mui/material";
+import { alpha, Box, Button, Chip, Typography, useTheme } from "@mui/material";
 import React, { useMemo, useState } from "react";
 
 import { categoryLabels } from "#/entities/category/model/categoryLabels";
@@ -152,7 +145,6 @@ export const ProjectBrowserCategoryBar: React.FC<
                   variant="filled"
                   sx={{
                     cursor: "pointer",
-                    fontWeight: isSelected ? 600 : 400,
                     backgroundColor: isSelected
                       ? theme.palette.info.main
                       : alpha(theme.palette.info.main, 0.12),


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Selecting a category chip in the project browser applied `fontWeight: 600`, which made the chip slightly wider and shifted surrounding chips.

## Solution

Remove the conditional bold styling. Selected state is already communicated by background color, text color, and border — no need for a weight change that affects layout.

## Changes

- `ProjectBrowserCategoryBar.tsx`: remove `fontWeight: isSelected ? 600 : 400` from category chip `sx`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6f69266b-d861-4ea4-9df3-91d6938c856e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6f69266b-d861-4ea4-9df3-91d6938c856e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

